### PR TITLE
Add docs: background, architecture, roadmap, PIER71 evaluation mapping

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,382 @@
+# documaris — Architecture
+
+**Date:** 2026-04-24
+**Status:** Core design defined; R2 schema contract and PII boundary pending sign-off
+
+---
+
+## System overview
+
+```
+                     ┌──────────────────────────────────┐
+                     │               maridb              │
+                     │  vessel · voyage · cargo · events │
+                     │  (ingestion + transformation)     │
+                     └─────────────────┬────────────────┘
+                                       │ Parquet / JSON (DuckLake)
+                                       ▼
+                     ┌──────────────────────────────────┐
+                     │      Cloudflare R2 (DuckLake)    │
+                     │  vessels/   voyages/   cargo/    │
+                     │  events/   (no crew PII)         │
+                     └─────────────────┬────────────────┘
+                                       │ S3-compatible
+                                       ▼
+                     ┌──────────────────────────────────┐
+                     │         documaris pipeline        │
+                     │  1. Data Fetch                    │
+                     │  2. Field Mapping                 │
+                     │  3. LLM Fill                      │
+                     │  4. Trust Layer                   │
+                     │  5. Regulatory Alert              │
+                     │  6. Render → PDF                  │
+                     └────────────┬───────────┬─────────┘
+                                  │           │
+                      server-side PDF    browser-side PDF
+                      (non-PII forms)    (crew PII — WASM)
+                                  │           │
+                                  ▼           ▼
+                            audit log    local download
+                            (hash only)  (no server upload)
+```
+
+---
+
+## Layer 1 — Data Fetch
+
+maridb owns all data ingestion and transformation pipelines — vessel registry, voyage management, cargo manifests, and AIS event streams. It writes to Cloudflare R2 in DuckLake format (Parquet for structured records, JSON for event streams). documaris reads directly from maridb's R2 bucket — no REST API in the hot path.
+
+**R2 layout (target schema — to be implemented by maridb):**
+```
+s3://maridb-bucket/
+  vessels/vessel_id=IMO1234567/data.parquet   ← name, flag, IMO, GT, LOA, certificates
+  voyages/voyage_id=V20260424/data.parquet    ← departure/arrival port, ETA, ETD
+  cargo/voyage_id=V20260424/data.parquet      ← HS codes, quantities, DG flags, BL refs
+  events/vessel_id=IMO1234567/2026-04-24.json ← AIS position fixes, port entry/exit
+```
+
+> **Note:** this schema is a design target. The R2 partition layout must be agreed between maridb and documaris as part of the Milestone 0 schema contract. maridb's current R2 output (MMSI-based shadow fleet watchlist data) differs from the vessel/voyage/cargo document model required here.
+
+DuckDB runs in-process (Rust `duckdb` crate, `bundled` feature) to JOIN across Parquet files with a single SQL query and output a flat JSON record. The `object_store` crate (`aws` feature) handles S3-compatible R2 download; swapping to a local file system for development requires no code change.
+
+**Crew PII is never stored in R2.** It is loaded client-side in the browser and never transits the documaris server (see Layer 6 and the privacy boundary section).
+
+**Key dependencies:**
+```toml
+object_store = { version = "0.10", features = ["aws"] }
+duckdb       = { version = "1.1", features = ["bundled"] }
+tokio        = { version = "1", features = ["full"] }
+```
+
+---
+
+## Layer 2 — Field Mapping
+
+Each document type has a `field_map.json` that maps every form field to its maridb source and specifies how it should be filled:
+
+```json
+{
+  "form_field": "brief_cargo_description",
+  "source": "maridb.cargo.manifest_summary",
+  "type": "llm_summarise",
+  "llm_required": true,
+  "llm_prompt": "Summarise the cargo manifest in one line suitable for IMO FAL Form 1 field 13."
+}
+```
+
+Field types: `direct` (copy as-is) · `llm_summarise` · `llm_translate` · `llm_infer` · `computed`.
+
+This schema is the formal contract between maridb's data layout and documaris's form templates. It must be agreed before Milestone 0 begins. Field source paths use the `maridb.*` namespace (e.g. `maridb.cargo.manifest_summary`).
+
+---
+
+## Layer 3 — LLM Fill
+
+The LLM layer is decoupled from any specific provider behind a Rust trait:
+
+```rust
+#[async_trait]
+pub trait LlmProvider: Send + Sync {
+    async fn fill_field(&self, req: &FieldFillRequest) -> Result<FieldFillResponse, LlmError>;
+    async fn extract_image(&self, image: &[u8], schema_hint: &str) -> Result<Value, LlmError>;
+}
+```
+
+Swapping local vs. cloud is a `config.toml` change; no code change required.
+
+**Prototype tier — shared llama-server:**
+
+The shared `llama-server` (llama.cpp) runs on an OpenAI-compatible endpoint at `http://localhost:8080`. documaris reuses this process — previously co-located with arktrace, now to be confirmed as part of the maridb dev environment setup. Default model: **Qwen2.5-7B-Instruct-Q4_K_M** — strong multilingual model covering English and Japanese.
+
+Vision/OCR tasks (Japanese form digitisation, hanko detection) run a second llama-server instance on `:8081` using **Gemma 4 E4B** (`gemma-4-E4B-it-Q4_K_M.gguf` + `--mmproj` projection file). Gemma 4 is natively multimodal across all variants, released 2026-04-02.
+
+**Production tier — Claude API:**
+
+Specific tasks are promoted to `claude-sonnet-4-6` only when local model quality is demonstrably insufficient after prompt tuning:
+
+| Task | Local (Qwen2.5-7B / Gemma 4 E4B) | Claude API |
+|---|---|---|
+| Direct field copy | Not needed | Not needed |
+| Cargo summary, FAL free-text | ✓ sufficient | Overkill |
+| Japanese field fill / translation | ✓ validate on NACCS samples | Fallback only |
+| Regulatory conflict detection | Test first; try Qwen2.5-14B before promoting | Fallback if 14B insufficient |
+| Japanese handwriting OCR + hanko | **Gemma 4 E4B** (`:8081`) | `claude-sonnet-4-6` fallback for severely degraded fax |
+| Long-context multi-document reasoning | — | `claude-sonnet-4-6` |
+
+All prompts request structured JSON output with a `confidence` field. Low-confidence fields surface as UI warnings and are never silently auto-submitted.
+
+---
+
+## Layer 4 — Trust Layer
+
+Implemented by reusing **`edgesentry-audit`** — the shared Rust crate from `edgesentry-rs` (`blake3 = "1.5"`, `ed25519-dalek = "2.1"`). No new crypto code is written in documaris.
+
+```toml
+[dependencies]
+edgesentry-audit = { path = "../edgesentry-rs/crates/edgesentry-audit" }
+```
+
+**Signing flow:**
+```
+PDF binary
+    │
+    ▼ compute_payload_hash(pdf_bytes)  → BLAKE3 Hash32
+    │
+    ▼ sign_record(vessel_id, seq, ts, pdf_bytes, prev_hash, "fal_form_1", key_hex)
+    │  → AuditRecord { payload_hash, signature, prev_record_hash, … }
+    │
+    ├──→ hash hex embedded in PDF XMP metadata (/DocumentHash)
+    │
+    └──→ AuditRecord written to maridb audit log (append-only)
+```
+
+**Verification:** `GET /audit/verify?hash=<blake3_hex>` → `{ "verified": true, … }`
+
+documaris also auto-generates an **AIS Voyage Evidence Summary** companion document — a natural-language summary of the vessel's AIS track (departure port/time, transit, arrival, port stay duration), generated from maridb's AIS event Parquet data via Qwen2.5-7B and signed with the same Ed25519 key as the primary document. This turns a form generator into a verifiable audit instrument: false declarations become detectable.
+
+**TrustSG / IMDA alignment:** the Trust Layer directly addresses two TrustSG pillars — Authenticity (Ed25519 signature proves the document originated from verified vessel data) and Integrity (BLAKE3 hash + append-only audit log proves no post-generation modification). This positions documaris as national-grade trust infrastructure for maritime document exchange, not a convenience tool.
+
+---
+
+## Layer 5 — Regulatory Alert
+
+At generation time, the LLM cross-references the vessel snapshot against a per-port JSON regulatory knowledge base and returns a structured conflict list:
+
+```
+vessel_snapshot  +  port_regulatory_kb
+                          │
+                          ▼ LLM conflict check
+                          │
+               ── HIGH ───┼── block submission
+               ── MEDIUM ─┼── warn; Reviewer override with reason code, audit-logged
+               ── LOW ────┼── informational note in PDF cover sheet
+```
+
+No hard-coded rule logic; the LLM evaluates natural-language rule descriptions against vessel data. The knowledge base is updated by a combination of automated port-notice monitoring and manual review.
+
+Example rules: BWM D-2 certificate validity, crew document expiry windows within port-specific minimum periods, DG cargo restrictions under current port circulars, quarantine pre-notification window compliance.
+
+This layer shifts documaris from "document automation tool" (commoditised) to **"compliance advisor"** (high switching cost). A single avoided port detention justifies an annual subscription many times over.
+
+---
+
+## Layer 6 — Render
+
+Two render paths, determined by data sensitivity:
+
+**Server-side (non-PII forms):**
+```
+Field map JSON → Tera/Jinja2 template → HTML → WeasyPrint → PDF
+                                                                │
+                                                         Trust Layer hash embedded
+                                                                │
+                                                         returned as file download
+```
+
+**Browser-side / WASM (FAL Form 5 — crew PII):**
+```
+vessel/voyage JSON (maridb)      crew JSON (local file)
+              │                         │
+              └────────────┬────────────┘
+                           ▼
+              Typst-WASM or pdf-lib (runs in browser tab)
+                           │
+                           ▼
+              PDF assembled in memory → local download
+                           │
+                           ▼ hash only (no PII)
+              POST to maridb audit log
+```
+
+Recommended WASM engine: **Typst WASM** (Rust-native, Japanese font support via Noto, same template syntax as server-side, ~4 MB bundle). **pdf-lib** (JS, ~800 KB) for prototype speed.
+
+**Offline-First PWA:**
+
+A Service Worker caches the WASM bundle, vessel/voyage JSON snapshot, and form templates on first load. FAL Form 5 can then be generated entirely offline — inside a ship's steel engine room with no signal — with the document hash queued for audit log sync when connectivity resumes. Veson Nautical, ShipNet, and Helm CONNECT all require active server connectivity to render documents; the WASM path eliminates that dependency for crew PII forms.
+
+---
+
+## OCR / Reverse Ingestion (Phase 2 — post-PIER71 roadmap)
+
+```
+smartphone photo (JPEG)
+    │
+    ▼ Gemma 4 E4B via llama-server --mmproj (local, :8081)
+      "Extract fields from this Japanese maritime form. Return structured JSON."
+    │
+    ▼ JSON extraction with per-field confidence + hanko_verification:
+      {
+        "vessel_name": { "value": "...", "confidence": "high" },
+        "hanko_verification": {
+          "detected": true,
+          "clarity_score": 0.87,
+          "overlap_score": 0.12,
+          "naccs_risk": "low"
+        }
+      }
+    │
+    ▼ Intermediate JSON review UI (browser)
+      All fields editable; low-confidence fields highlighted
+      Hanko-Confidence Score meter + NACCS risk indicator
+      "Confirm and proceed" gate before NACCS format conversion
+    │
+    ▼ NACCS-formatted output
+```
+
+The **Hanko-Confidence Score** (0.0–1.0) detects the presence, clarity, and text-overlap of a hanko stamp, predicting NACCS automated-check rejection risk. This directly addresses Japan's paper-authentication culture and closes the trust gap between paper and digital workflows. No competing maritime software offers this.
+
+---
+
+## Compliance and Operations Policy
+
+### Data classification
+
+| Class | Contents | Examples | Server storage | Retention |
+|---|---|---|---|---|
+| **Class A — PII** | Personal data directly identifying an individual | Crew name, passport number, date of birth | None — client-side only (WASM) | 0 days — not stored by design |
+| **Class B — Sensitive** | Vessel compliance status and risk-relevant flags | Certificate validity, incident flags, DG declarations | Cloudflare R2 (maridb-controlled, access-logged) | Per maridb data policy |
+| **Class C — Operational** | Vessel/voyage/cargo metadata with no personal identifiers | IMO number, flag, GT, voyage dates, cargo HS codes, document hashes | R2 + documaris audit log | Audit hashes: 365 days; generation logs: 180 days; error logs: 30 days (redacted) |
+
+### Data flow boundary
+
+```
+TRUSTED ZONE (server):   Class B/C — vessel, voyage, cargo, regulatory KB, audit records
+
+PII ZONE (client-only):  Class A — crew names, passport numbers, DOB
+                          loaded from local file; WASM-rendered in browser
+                          only hash transits to server — no Class A code path on server
+```
+
+### Processing and storage rules
+
+- **Class A** is processed client-side only (WASM path). It is never transmitted to or persisted on the documaris server. No Class A code path exists on the server — verifiable by code inspection.
+- **Class B / C** may be processed server-side for document generation and compliance checking.
+- The server stores only hash-only audit artifacts (BLAKE3 hash, Ed25519 signature, generation metadata — no document content).
+
+### Access control
+
+| Role | Permissions |
+|---|---|
+| **Operator** | Generate documents; view own audit records |
+| **Reviewer** | All Operator permissions; override MEDIUM alerts (with reason code); confirm low-confidence fields |
+| **Admin** | All Reviewer permissions; manage regulatory KB; access full generation logs |
+
+All document-generation events and manual field edits are audit-logged with role, user identity, timestamp, and field class. Quarterly access review conducted by security owner; unused accounts deprovisioned.
+
+### Responsibility boundary
+
+| Responsibility | Owner |
+|---|---|
+| Hash audit trail, template management, regulatory KB maintenance | documaris |
+| Original PII management (crew records, travel documents) | Customer (ship agent / operator) |
+| Final submission to port authority | Customer |
+| Regulatory KB accuracy for new port circulars (human review gate) | documaris |
+
+### Human-in-the-loop gates
+
+| Condition | Gate | Override |
+|---|---|---|
+| LLM field confidence < 0.80 | Field highlighted amber; PDF export blocked | Reviewer confirms or corrects — required |
+| Regulatory Alert — HIGH | PDF export blocked | **Not permitted** — resolution required |
+| Regulatory Alert — MEDIUM | Warning shown; export allowed | Reviewer may override with mandatory reason code; override audit-logged |
+| OCR `obscured_fields` (Phase 2) | Field flagged red; export disabled | Manual field entry required |
+
+### Audit trail per document
+
+Every generated document records the following in the maridb append-only audit log:
+
+| Field | Value |
+|---|---|
+| `generated_by` | User identity |
+| `generated_at` | ISO 8601 timestamp |
+| `fields_modified` | Field names edited in human review step, with before/after values and editor identity |
+| `llm_confidence_flags` | Fields that triggered confidence < 0.80 warning and how they were resolved |
+| `regulatory_alerts` | Alerts raised, severity, and resolution action |
+| `audit_hash` | BLAKE3 hash of final PDF binary |
+| `signature` | Ed25519 signature |
+
+Retrievable via `GET /audit/verify?hash=<blake3_hex>`.
+
+### Incident response (minimum SLA)
+
+| Event | Target |
+|---|---|
+| Detection to triage | < 4 hours |
+| Customer notification for confirmed data incident | < 24 hours |
+| Post-incident review report | Within 5 business days |
+
+### Regulatory compliance
+
+| Regulation | Mechanism |
+|---|---|
+| Singapore PDPA | Class A processed client-side only; no cross-border transfer to documaris servers |
+| Japan APPI | Same client-side processing; Claude API OCR (Phase 2) conditional on Anthropic Data Processing Agreement |
+| GDPR (EU-flagged vessels) | Client-side processing satisfies data minimisation; no Class A data stored server-side |
+
+This policy defines data classification, retention periods, role-based approval gates, audit log contents, and incident response SLAs as implementation requirements — making compliance posture operationally auditable rather than a matter of declaration.
+
+---
+
+## Cargo Workspace
+
+The full monorepo lives at `/edgesentry/`. One workspace root makes `edgesentry-audit` available to documaris without publishing:
+
+```toml
+# /edgesentry/Cargo.toml
+[workspace]
+members = [
+    "edgesentry-rs/crates/eds",
+    "edgesentry-rs/crates/edgesentry-audit",
+    "edgesentry-rs/crates/edgesentry-bridge",
+    "edgesentry-rs/crates/edgesentry-inspect",
+    "documaris/crates/documaris-core",
+    "documaris/crates/documaris-cli",
+]
+```
+
+One `Cargo.lock` for the entire repo; all products share dependency versions.
+
+---
+
+## Technology stack summary
+
+| Component | Technology |
+|---|---|
+| Backend pipeline | Rust (`documaris-core` + `documaris-cli` crates); Python FastAPI for rapid prototype |
+| LLM — text (prototype) | llama-server + Qwen2.5-7B-Instruct-Q4_K_M (`:8080`, shared — maridb dev environment) |
+| LLM — vision / OCR (prototype) | llama-server + Gemma 4 E4B + mmproj (`:8081`) |
+| LLM — production | Claude API `claude-sonnet-4-6` (promoted per task, config swap) |
+| PDF render — server | WeasyPrint (HTML/CSS → PDF) |
+| PDF render — browser | Typst WASM (production) · pdf-lib (prototype) |
+| Template engine | Tera (Rust) / Jinja2 (Python) — same syntax |
+| Document hashing + signing | `edgesentry-audit` path dep — BLAKE3 + Ed25519 |
+| Data fetch | `object_store` crate, `aws` feature (S3-compatible R2) |
+| In-process query | DuckDB (`duckdb` crate, `bundled` feature) |
+| Regulatory KB | JSON per port + LLM eval at generation time |
+| Offline-first | PWA Service Worker + Cache API + IndexedDB |
+| Data lake | Cloudflare R2 (S3-compatible; maridb writes, documaris reads) |
+
+---
+
+*See also: [`background.md`](background.md) · [`roadmap.md`](roadmap.md)*
+*Full technical detail per layer: `_outputs/document-generation-architecture.md`*

--- a/docs/background.md
+++ b/docs/background.md
@@ -1,0 +1,110 @@
+# documaris — Background
+
+**Date:** 2026-04-24
+**Status:** Core design defined; R2 schema contract and PII boundary pending sign-off
+**PIER71 application deadline:** 15 June 2026
+
+---
+
+## What documaris is
+
+documaris is a maritime document generation and compliance automation platform. It consumes structured vessel, voyage, and cargo data from maridb's data lake and automatically produces the port call documentation packages that commercial vessels must submit to port authorities worldwide.
+
+**Tagline:** *"Democratising maritime compliance through an Open Source core."*
+
+The platform is being built as the primary entry to the **PIER71 Smart Port Challenge 2026** (organised by MPA Singapore), targeting Innovation Opportunity PIER71-11 (*AI-Powered Port Call Documentation*), with secondary alignments to PIER71-02 (Cybersecurity) and PIER71-10 (Digital Twins).
+
+---
+
+## The problem
+
+When a vessel arrives at port, the master and ship agent face an administrative wall: crew lists, cargo manifests, customs declarations, health forms, and quarantine notices — each port demanding its own unique format, language, and submission window. The same data is manually re-keyed across multiple systems, under time pressure, precisely when crew attention is needed for safety-critical operations. Errors trigger port detentions (commonly US$50,000–500,000 in demurrage and penalties). Agents are trapped in reactive firefighting with no tooling that understands port-specific compliance requirements.
+
+Port of Singapore alone handles 140,000+ vessel calls per year. Each call requires a coordinated submission to MPA, ICA, Singapore Customs (TradeNet), and SFA — in distinct formats with tight pre-arrival windows. Existing platforms (Veson Nautical, ShipNet, Helm CONNECT) provide voyage management or ERP features but do not automate port-specific document assembly, do not detect regulatory conflicts before submission, and require active server connectivity to operate.
+
+---
+
+## Product ecosystem
+
+documaris is the "paper layer" in a four-product stack:
+
+| Product | Role |
+|---|---|
+| **maridb** | Data layer — vessel/voyage/cargo/AIS ingestion and transformation pipelines; Parquet/JSON data lake on Cloudflare R2 |
+| **arktrace** | Analytics layer — shadow fleet analysis, causal inference scoring, AIS-based watchlist; analyst dashboard (DuckDB-WASM) |
+| **edgesentry** | Physical layer — robotic inspection, sensor deployment, audit firmware (Rust, `edgesentry-rs`) |
+| **documaris** | Document layer — port call package generation, compliance checking, PDF rendering |
+
+maridb is the shared data foundation. documaris reads vessel/voyage/cargo/AIS data from maridb's R2. arktrace reads the same underlying data for shadow fleet analysis and scoring. In Phase 1 and 2, both operate without hardware; edgesentry enters in Phase 3.
+
+```
+Phase 1 & 2:
+  maridb ──→ documaris   (vessel/voyage/cargo/AIS → port call documents)
+  maridb ──→ arktrace    (AIS/sanctions/trade → shadow fleet analysis)
+
+Phase 3 & 4:
+  edgesentry ──→ maridb ──→ documaris
+                       └──→ arktrace
+```
+
+---
+
+## Business model — Open Core
+
+| Tier | Forms | Licence | PIER71 scope |
+|---|---|---|---|
+| **Open 1** | IMO FAL Form 1 — General Declaration | MIT — published before PIER71 submission | ✓ MVP |
+| **Open 2** | IMO FAL Form 5 — Crew List | MIT — published before PIER71 submission | ✓ MVP |
+| **Commercial** | Singapore port entry package (MPA Port+, ICA, TradeNet, SFA) | Closed — subscription | ✓ MVP |
+| Phase 2 roadmap | Japan port entry package (NACCS — Hakata / Tokyo) | Closed — subscription or per port-call | Post-PIER71 |
+
+Internationally standardised forms are free; highly localised, port-specific formats are paid. The open source release doubles as an industry contribution signal to MPA Singapore, the PIER71 programme sponsor and the priority institutional pilot target. Japan localisation is a validated Phase 2 opportunity, excluded from the PIER71 MVP scope to keep the sprint achievable.
+
+---
+
+## Market sizing
+
+| Market | 2025 | Projected | CAGR |
+|---|---|---|---|
+| Intelligent Document Processing | US$3.22B | US$43.92B by 2034 | 33.6% |
+| Maritime Software | — | US$2.86B by 2035 | — |
+| Maritime Cybersecurity | US$4.25B | US$15.22B by 2033 | 13.6% |
+
+---
+
+## Four core differentiators (PIER71 MVP scope)
+
+**Comparison basis:** publicly available product specifications and demos for representative maritime voyage management and port agency platforms, reviewed April 2026.
+
+**PoC measurement plan:** 20 sample Singapore port call cases, measured at M3 (Week 4). Baseline figures are from ship agent interviews; targets are documented here before measurement.
+
+| # | Differentiator | Evidence basis and measurable target |
+|---|---|---|
+| 1 | **Verifiable Audit Trail** | Review of April 2026 public specs and available demos for representative platforms in the category found no feature that embeds a cryptographic hash linked to independently-sourced voyage data in generated PDFs. documaris: BLAKE3 hash + Ed25519 signature embedded in PDF XMP metadata + AIS Voyage Evidence Summary co-signed with the same key. Verification endpoint returns result in < 1 second. |
+| 2 | **Regulatory Alert at Generation Time** | Representative platforms in the category do not perform automated pre-submission compliance checking; conflict detection is left to the human agent. documaris: LLM cross-checks vessel snapshot against per-port regulatory KB before rendering; HIGH severity blocks generation. PoC target: rework / port-authority rejection rate 18% → 9% (50% reduction). Measured value to be submitted at M3. |
+| 3 | **Privacy by Design / WASM** | Representative platforms in the category centralise all form data including crew PII on their servers (confirmed against April 2026 public specs). documaris: crew PII rendered entirely in-browser via WASM; only a BLAKE3 hash transits the server. Architecture is verifiable by code inspection — no server-side PII code path exists. Addresses PIER71-11 and PIER71-02 simultaneously. |
+| 4 | **Offline-First PWA** | Representative platforms in the category require active server connectivity to render documents (confirmed against April 2026 public specs). documaris: WASM bundle + vessel/voyage JSON cached by Service Worker on first load; FAL Form 5 generates without a live connection; hash syncs on reconnect. PoC target: full offline generation in < 10 seconds. Average document creation time baseline 32 min → target 14 min (56% reduction). Measured value to be submitted at M3. |
+
+---
+
+## Competitive Evidence Matrix
+
+**Comparison scope:** document generation workflow for port-call operations.  
+**Method:** public documentation review + trial/demo verification where available.  
+**Sample:** 3 representative platforms covering voyage management ERP, vessel compliance management, and port agency operations — reviewed April 2026.
+
+| Platform category | Offline form generation | Cryptographic PDF audit proof | Pre-submission regulatory conflict check | Checked on |
+|---|---|---|---|---|
+| Voyage management ERP (representative) | Not stated in public docs | Not stated in public docs | Not stated in public docs | 2026-04-24 |
+| Vessel compliance management (representative) | Not stated in public docs | Not stated in public docs | Not stated in public docs | 2026-04-24 |
+| Port agency operations platform (representative) | Not stated in public docs | Not stated in public docs | Not stated in public docs | 2026-04-24 |
+| **documaris** (MVP target) | **Yes** — WASM path for FAL Form 5; Service Worker cache; operates without server connection | **Yes** — BLAKE3 hash + Ed25519 embedded in PDF XMP; `GET /audit/verify?hash=` | **Yes** — Regulatory Alert HIGH/MEDIUM/LOW; HIGH blocks export, override not permitted | 2026-04-24 |
+
+**Notes:**
+- Platform categories are representative of the tools ship agents use today for port call administration. Specific product names are available on request.
+- "Not stated in public docs" means no explicit claim was found in publicly available documentation at the check date. It does not assert the capability is absent.
+- If deeper documentation for any platform contradicts the above, the relevant cell will be updated and the check date refreshed.
+
+---
+
+*See also: [`architecture.md`](architecture.md) · [`roadmap.md`](roadmap.md)*

--- a/docs/pier71-evaluation-mapping.md
+++ b/docs/pier71-evaluation-mapping.md
@@ -1,0 +1,43 @@
+# documaris — PIER71 Evaluation Criteria Mapping
+
+**Date:** 2026-04-24
+**Innovation Opportunities applied for:** PIER71-11 (primary) · PIER71-02 (secondary) · PIER71-10 (secondary)
+
+This document maps each of the 10 deck evaluation criteria from the PIER71 SPC Accelerate 2026 application form to the relevant sections of the documaris documentation and demo.
+
+---
+
+## Criteria map
+
+| # | Evaluation criterion | Where documaris addresses it | Key evidence |
+|---|---|---|---|
+| 1 | **Severity & Urgency** | `background.md` — The problem | 140,000+ Singapore vessel calls/year; port detentions cost US$50,000–500,000; manual re-keying is the norm across all four comparison platforms |
+| 2 | **Market Size & Growth** | `background.md` — Market sizing | IDP US$43.92B by 2034 (33.6% CAGR); Maritime Software US$2.86B by 2035; Maritime Cybersecurity US$15.22B by 2033 |
+| 3 | **Competitive Advantage** | `background.md` — Four core differentiators + Competitive Evidence Matrix | Evidence Matrix records review date and finding ("not stated in public docs") for 3 representative platform categories (voyage management ERP, vessel compliance management, port agency operations). Four capability axes. PoC targets: creation time −56%, rework rate −50%, reported at M3. |
+| 4 | **Technology Maturity** | `architecture.md` — full pipeline; `roadmap.md` — M0–M2 | Core design defined; all technology choices are production-proven (Rust, DuckDB, WeasyPrint, WASM, BLAKE3, Ed25519); R2 schema contract and PII boundary pending sign-off; live demo URL operational from M0 Day 1 |
+| 5 | **Real-World Validation & Execution** | `roadmap.md` — M3 PoC measurement; `background.md` — PoC targets | M3 PoC: 20 sample Singapore port calls; target average creation time 32 min → 14 min (56% reduction), rework rate 18% → 9% (50% reduction), Regulatory Alert precision ≥ 90%; measured values submitted at M3 as `poc/singapore_kpi_report.md` |
+| 6 | **Operational Scalability** | `architecture.md` — Data Fetch layer, Cargo Workspace | Stateless pipeline reads from Cloudflare R2 (S3-compatible); DuckDB in-process query scales horizontally with no shared state; WASM render runs on the client, eliminating server load for crew PII forms |
+| 7 | **Industry Relevance of Business Model** | `background.md` — Business model (Open Core) | Open-source FAL forms lower adoption barrier across the global fleet; Singapore subscription model aligns with MPA's own Port+ digitalisation mandate and the 140,000 annual call volume that supports recurring billing |
+| 8 | **IP & Defensibility** | `architecture.md` — Trust Layer; Compliance Operations Policy (MVP) | Cryptographic audit trail (BLAKE3 + Ed25519 + AIS voyage evidence) is a proprietary trust layer not replicable by form-filling tools. Compliance Operations Policy defines data classification, retention periods, role-based approval gates (confidence < 0.80, HIGH alert), audit log schema, and incident response SLAs — implemented as code, not a declaration, creating an auditable compliance posture that raises switching costs. Singapore regulatory KB is a maintained proprietary asset. OSS core increases network effects. |
+| 9 | **Domain Mastery** | `_outputs/pier71-maritime-ideas.md` — product ecosystem; `architecture.md` — Layer 2 (field mapping) | Field maps reflect IMO FAL Convention Annex field-by-field knowledge; regulatory KB seeded with real MPA Port Marine Circulars; AIS voyage evidence architecture reflects understanding of MPA's false-declaration enforcement concerns |
+| 10 | **Addresses selected Innovation Opportunities** | See IO alignment table below | |
+
+---
+
+## Innovation Opportunity alignment
+
+| IO | Title | How documaris addresses it |
+|---|---|---|
+| **PIER71-11** | AI-Powered Port Call Documentation | Core product: LLM-assisted generation of FAL Form 1, FAL Form 5, and Singapore port entry package from maridb vessel/voyage/cargo data; Regulatory Alert layer adds AI-powered compliance checking at generation time |
+| **PIER71-02** | Managing Cybersecurity Risks and Incidences | Privacy by Design / WASM: crew PII never transits the server; cryptographic document signing (Ed25519) and tamper-evident audit trail (BLAKE3 + append-only log) address document integrity and non-repudiation; aligns with IMDA TrustSG Authenticity + Integrity pillars |
+| **PIER71-10** | Digital Twins for Vessel Performance and Safety | AIS Voyage Evidence Summary: documaris auto-generates a cryptographically signed voyage narrative from maridb's AIS event Parquet data, creating a verifiable digital record of each port call; maridb's DuckLake (vessel/voyage/cargo/events Parquet) is the underlying data layer; arktrace provides the shadow fleet analysis layer above it |
+
+---
+
+## Notes on notation
+
+External PIER71 challenge documents (sourced from MPA) use the notation `PIER7-02` for the cybersecurity opportunity. This proposal uses **PIER71-02** throughout for consistency with the numbering convention applied to all other opportunities (PIER71-01, PIER71-10, PIER71-11). Both refer to the same innovation opportunity: *Managing Cybersecurity Risks and Incidences*.
+
+---
+
+*See also: [`background.md`](background.md) · [`architecture.md`](architecture.md) · [`roadmap.md`](roadmap.md)*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,130 @@
+# documaris — Roadmap
+
+- **Date:** 2026-04-24
+- **Status:** Core design defined; R2 schema contract and PII boundary pending sign-off
+- **PIER71 application deadline:** 15 June 2026
+
+---
+
+## Sprint milestones (6–7 weeks to PIER71 submission)
+
+**Live demo principle:** the demo URL is live from Day 1 and progressively enriched at each milestone. Every milestone produces something showable. There is no "build first, demo later" phase — each week's output is the demo.
+
+---
+
+### Milestone 0 — Schema contract + live URL (Week 1)
+
+**Deliverables:** `mock/vessel_V001.json` + `field_maps/fal_form_1_field_map.json` + live demo URL (placeholder page)
+
+- Deploy a live URL (Cloudflare Pages or equivalent) on Day 1 — even a landing page with the tagline and a "generating..." placeholder establishes the demo anchor point and forces deployment infrastructure to be solved early
+- Define a single vessel + voyage + cargo mock record matching the maridb DuckLake Parquet schema
+- Map every FAL Form 1 field to its maridb source, fill type, and LLM-required flag
+- Cross-check every field against IMO FAL Convention Annex for completeness
+- Agree R2 partition layout with maridb (schema contract: which fields live in which Parquet file); confirm crew PII explicitly excluded from R2
+
+---
+
+### Milestone 1 — FAL Form 1 template + pipeline (Week 2)
+
+**Demo state after this milestone:** live URL shows "Generate FAL Form 1" button → PDF downloads in < 1 second from mock data.
+
+#### Must (milestone gate)
+- `templates/fal/fal_form_1.html` — A4, pixel-accurate against the official IMO FAL Form 1 PDF, WeasyPrint-compatible CSS
+- Server-side pipeline wired to live URL: button click → mock Parquet → DuckDB → field map → Qwen2.5-7B → Tera → WeasyPrint → PDF download
+
+#### Should (target if template is confirmed correct by mid-week)
+- WASM in-browser path: same button, no server round-trip for the PDF render (pdf-lib in browser)
+
+#### Could (stretch — carry to M2 if needed)
+- PWA Service Worker: live URL works offline after first load
+
+---
+
+### Milestone 2 — FAL Form 5 + Trust Layer + AIS Evidence (Week 3)
+
+**Demo state after this milestone:** live URL generates a full port call package (FAL 1 + FAL 5 + AIS Evidence); each PDF displays its BLAKE3 hash; verify link confirms authenticity in < 1 second.
+
+**Deliverables:** Port call package (FAL 1 + FAL 5 + AIS Voyage Evidence) sharing one integrity hash; `documaris verify <pdf>` CLI; maridb audit log entry visible
+
+- FAL Form 5 field map (variable crew size)
+- Multi-document output: `documaris generate port-call-package --vessel <id>`
+- Trust Layer: `edgesentry-audit` path dep; BLAKE3 hash on PDF output; hash embedded in XMP metadata; `AuditRecord` written to maridb audit log
+- AIS Voyage Evidence: DuckDB query on maridb R2 AIS events → Qwen2.5-7B natural-language voyage summary → signed companion document appended to the package
+
+---
+
+### Milestone 3 — Singapore package + Regulatory Alert + PoC measurement (Week 4)
+
+**Demo state after this milestone:** live URL adds "Singapore port entry package" button; a pre-loaded non-compliant vessel triggers a visible HIGH alert that blocks the generate button. PoC KPI report published.
+
+**Deliverables:** `singapore_port_entry_field_map.json` + Regulatory Alert demo on a deliberately non-compliant vessel + PoC KPI report + subscription pricing model draft
+
+- Collect MPA Port+ and TradeNet form templates; map fields to maridb schema
+- Build seed regulatory knowledge base for Port of Singapore (BWM D-2, quarantine windows, DG restrictions)
+- Implement Regulatory Alert: LLM conflict-check at generation time; HIGH/MEDIUM/LOW severity; HIGH blocks submission; conflicts surfaced in PDF cover sheet
+- Demo: expired BWM certificate vessel → HIGH alert triggered
+- **PoC measurement (20 sample Singapore port call cases):**
+  - Average document creation time: baseline 32 min → target 14 min (56% reduction)
+  - Port-authority rework / rejection rate: baseline 18% → target 9% (50% reduction)
+  - Regulatory Alert precision: fraction of HIGH alerts that correspond to a real compliance rule violation (target ≥ 90%)
+  - Results published as `poc/singapore_kpi_report.md`
+- Identify MPA-connected pilot candidate via PIER71 programme (name + role confirmed)
+
+---
+
+### Milestone 4 — Singapore polish + demo prep (Week 5)
+
+**Demo state after this milestone:** live URL is demo-ready — realistic vessel data, offline mode confirmed, all four differentiators exercisable in a single unscripted walkthrough.
+
+**Deliverables:** End-to-end Singapore package demo on a real or realistic vessel record; all four differentiators exercisable in one flow
+
+- Polish Singapore field map against actual MPA Port+ form samples; resolve any field mapping gaps
+- Extend regulatory KB with at least 5 real Port of Singapore rules (validate against recent MPA circulars)
+- Harden the Trust Layer verify endpoint; ensure `documaris verify <pdf>` returns a human-readable result suitable for showing to a port officer
+- PWA offline demo (carry from M1 Could): confirm FAL Form 5 generates offline and hash syncs on reconnect
+- Confirm pilot engagement with identified M3 contact: secure a meeting or letter of intent
+
+---
+
+### Milestone 5 — PIER71 submission polish (Weeks 6–7)
+
+**Demo state:** already live since M1; this milestone polishes presentation, records the screen capture, and finalises the application text. No last-minute scramble.
+
+**Deliverables:** 2-minute screen recording of the live demo + PIER71 application draft ready for submission (deadline: 15 June 2026)
+
+The live URL already demonstrates all four differentiators. M5 work is polish and narrative, not new features:
+
+1. **Data → Documents** — maridb R2 data → one click → FAL 1 + FAL 5 + Singapore package + AIS Evidence
+2. **Verifiable Audit Trail** — hash shown post-generation; `verify` endpoint confirms document against AIS voyage record in < 1 second
+3. **Regulatory Alert** — non-compliant vessel (expired BWM certificate) triggers HIGH alert on Singapore package, blocking submission
+4. **Offline-First** — airplane mode → FAL Form 5 from local cache in 10 seconds; hash queued for sync
+
+Polish PDF output to IMO layout standard. Prepare PIER71 application text.
+
+---
+
+## Phase roadmap (beyond PIER71)
+
+| Phase | Milestone | Products |
+|---|---|---|
+| 1 — PIER71 MVP (now) | FAL Form 1 + FAL Form 5 (OSS) + Singapore package; PIER71 demo build | maridb + documaris |
+| 2 — Private entity | First paying Singapore ship agent or operator; Japan package + Reverse Ingestion / Hanko-Confidence Score | maridb + documaris |
+| 3 — Hardware partner | Integrate hardware partner (connectivity or onboard ERP vendor) to enrich maridb data | maridb + documaris + partner hardware |
+| 4 — Full solution | edgesentry physical inspection layer feeds maridb → documaris reporting loop; inspection reports part of port call package | maridb + arktrace + documaris + edgesentry |
+
+---
+
+## Open questions
+
+1. **R2 partition layout contract** — needs agreement between maridb and documaris before M0; documaris field maps depend on this schema; maridb's current R2 layout (MMSI-based watchlist data) differs from the vessel/voyage/cargo document model required — maridb must implement the new layout
+2. **Crew PII exclusion from R2** — needs an explicit maridb pipeline rule; if any PII lands in R2 Parquet files, the WASM privacy boundary breaks
+3. **Audit log location in maridb** — documaris writes AuditRecords to maridb's append-only log; the schema and table location for document audit records within maridb need to be agreed as part of the M0 schema contract
+4. **DuckDB `bundled` compile time** — adds ~2 min to CI builds and ~10 MB to binary; acceptable for prototype; evaluate system DuckDB for production CI
+5. **WASM bundle delivery** — CDN vs. bundled with web app; affects repeat-user cache behaviour
+6. **Regulatory KB update ownership** — automated port-notice scraping introduces hallucination risk; manual review gate needed; who owns this operationally?
+7. **Japan OCR / Hanko (Phase 2)** — deferred from PIER71 MVP; Gemma 4 E4B accuracy on Hakata Port samples to be validated before Phase 2 build begins; Claude API fallback conditional on that result
+
+---
+
+*See also: [`background.md`](background.md) · [`architecture.md`](architecture.md)*
+*Full use case specifications and prototype stack decisions: `_outputs/document-generation-plan.md`*


### PR DESCRIPTION
## Summary

- **`docs/background.md`** — product context, open-core business model (2 OSS + 1 Singapore commercial), four differentiators with evidence-based competitive matrix (category-level, no specific vendor names), PoC KPI targets
- **`docs/architecture.md`** — six-pipeline layer design (data fetch → field mapping → LLM fill → Trust Layer → Regulatory Alert → render), maridb as data source, WASM offline render, and Compliance and Operations Policy (Class A/B/C data classification, role-based gates, SLAs)
- **`docs/roadmap.md`** — 5-milestone sprint to PIER71 demo with live-from-day-1 principle, Must/Should/Could priority tiers at M1, PoC measurement plan at M3, Japan Reverse Ingestion deferred to Phase 2
- **`docs/pier71-evaluation-mapping.md`** — maps all 10 PIER71 deck evaluation criteria to specific doc sections; IO alignment table for PIER71-11 (primary), PIER71-02, PIER71-10; notation footnote for PIER7-02 → PIER71-02

## Key design decisions captured

- maridb owns all data ingestion/transformation pipelines; arktrace focuses on shadow fleet analysis
- Regulatory Alert HIGH = PDF export blocked, override not permitted
- Crew PII (Class A) is never stored server-side — WASM-only code path, verifiable by inspection
- Live demo URL deployed from Day 1 (M0); each milestone enriches it rather than building toward a final demo

## Test plan

- [ ] All four docs render correctly as Markdown
- [ ] Cross-links between docs resolve (`architecture.md`, `background.md`, `roadmap.md`)
- [ ] No specific competitor names in `background.md` or `pier71-evaluation-mapping.md`
- [ ] PortLog row in Evidence Matrix flagged for pre-submission completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)