### PR TITLE
Add MkDocs GitHub Pages setup

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,52 @@
+name: Pages
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "mkdocs>=1.5,<2.0" "mkdocs-material>=9.5,<9.6"
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deploy
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_inputs/
+_outputs/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
 # documaris
+
+**Democratising maritime compliance through an Open Source core.**
+
+documaris automates the port call documentation that commercial vessels must submit to port authorities worldwide. Ship agents and masters currently re-key the same vessel, voyage, and cargo data into multiple forms — under time pressure, in port-specific formats, in multiple languages. documaris generates those documents from a single data source, checks them for regulatory conflicts before submission, and produces a cryptographically verifiable audit trail.
+
+Built for the [PIER71 Smart Port Challenge 2026](https://pier71.sg) — Innovation Opportunity PIER71-11 (AI-Powered Port Call Documentation).
+
+---
+
+## What it does
+
+1. **Pulls vessel, voyage, and cargo data** from [maridb](../maridb)'s data lake (Cloudflare R2)
+2. **Fills port call forms** using field maps and an LLM — free-text fields, translations, and inferred values handled automatically
+3. **Checks for regulatory conflicts** against a per-port knowledge base before generating the PDF — expired certificates, missed pre-notification windows, and DG restrictions surface as HIGH/MEDIUM/LOW alerts
+4. **Renders PDFs** server-side for non-PII forms; entirely in-browser via WASM for crew data (FAL Form 5) — crew PII never transits the server
+5. **Signs every document** with a BLAKE3 hash + Ed25519 signature and appends an AIS Voyage Evidence Summary — the full package is cryptographically verifiable
+
+---
+
+## Document scope (PIER71 MVP)
+
+| Tier | Form | Status |
+|---|---|---|
+| Open source (MIT) | IMO FAL Form 1 — General Declaration | MVP |
+| Open source (MIT) | IMO FAL Form 5 — Crew List | MVP |
+| Commercial | Singapore port entry package (MPA Port+, ICA, TradeNet, SFA) | MVP |
+| Phase 2 roadmap | Japan port entry package (NACCS — Hakata / Tokyo) | Post-PIER71 |
+
+---
+
+## Product stack
+
+```
+maridb        data ingestion + transformation → Cloudflare R2
+arktrace      shadow fleet analysis + AIS watchlist (reads from maridb)
+documaris     port call document generation (reads from maridb)
+edgesentry    physical inspection layer (enters Phase 3)
+```
+
+---
+
+## Documentation
+
+| Document | Contents |
+|---|---|
+| [docs/background.md](docs/background.md) | What documaris is, the problem it solves, business model, and competitive differentiators |
+| [docs/architecture.md](docs/architecture.md) | Six-layer pipeline design, Trust Layer, Regulatory Alert, WASM offline render, Compliance and Operations Policy |
+| [docs/roadmap.md](docs/roadmap.md) | Sprint milestones (M0–M5) to PIER71 submission, PoC KPI targets, phase roadmap beyond PIER71 |
+| [docs/pier71-evaluation-mapping.md](docs/pier71-evaluation-mapping.md) | Maps all 10 PIER71 deck evaluation criteria to specific doc sections |
+
+---
+
+## Status
+
+Core design defined. R2 schema contract and PII boundary with maridb pending sign-off.
+Sprint underway — live demo URL goes live at Milestone 0 (Week 1).
+
+**PIER71 application deadline: 15 June 2026**

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,26 @@
+# documaris
+
+**Maritime document generation and compliance automation platform.**
+
+documaris consumes structured vessel, voyage, and cargo data from the [maridb](https://github.com/edgesentry/maridb) data layer and automatically produces the port call documentation packages that commercial vessels must submit to port authorities worldwide.
+
+## Quick links
+
+- [Background](background.md) — product context, market positioning, open-core model
+- [Architecture](architecture.md) — six-layer pipeline, data flow, compliance policy
+- [Roadmap](roadmap.md) — milestones M0–M3, open questions
+- [PIER71 Evaluation Mapping](pier71-evaluation-mapping.md) — alignment with Smart Port Challenge 2026 criteria
+
+## Product stack
+
+| Product | Role |
+|---|---|
+| **maridb** | Data layer — vessel/voyage/cargo/AIS ingestion and transformation |
+| **arktrace** | Analytics layer — shadow fleet analysis, causal inference scoring |
+| **documaris** | Document layer — port call package generation, compliance checking |
+| **edgesentry** | Physical layer — robotic inspection, sensor deployment |
+
+## Source
+
+- GitHub: [github.com/edgesentry/documaris](https://github.com/edgesentry/documaris)
+- PIER71 Smart Port Challenge 2026 application deadline: **15 June 2026**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,32 @@
+site_name: documaris
+site_description: Maritime document generation and compliance automation platform.
+site_url: https://edgesentry.github.io/documaris/
+repo_url: https://github.com/edgesentry/documaris
+repo_name: edgesentry/documaris
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - content.action.edit
+
+nav:
+  - Home: index.md
+  - Background: background.md
+  - Architecture: architecture.md
+  - Roadmap: roadmap.md
+  - PIER71 Evaluation Mapping: pier71-evaluation-mapping.md


### PR DESCRIPTION
Closes #4

## Changes
- **`mkdocs.yml`** — MkDocs Material theme with light/dark toggle, nav for all 4 existing docs
- **`.github/workflows/pages.yml`** — build + deploy to GitHub Pages on push to main (mirrored from arktrace)
- **`docs/index.md`** — landing page with product stack overview and quick links

## After merging
Enable GitHub Pages in repo Settings → Pages → Source: **GitHub Actions**.

Published at: https://edgesentry.github.io/documaris/

🤖 Generated with [Claude Code](https://claude.com/claude-code)