### PR TITLE
architecture, roadmap: TC1–TC4 demo gates, edgesentry-audit boundary, Mermaid diagrams

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,53 +9,24 @@
 
 ## System overview
 
-```
-  ┌─────────────────────────────────────────────────────┐
-  │  REMOTE (maridb)                                    │
-  │  vessel · voyage · cargo · events                   │
-  │  → copies required data to documaris R2 bucket      │
-  └───────────────────────┬─────────────────────────────┘
-                          │ push (maridb job)
-                          ▼
-  ┌─────────────────────────────────────────────────────┐
-  │  REMOTE (documaris R2 bucket — read-only for app)   │
-  │    vessels / voyages / cargo / events (Parquet/JSON) │
-  └───────────────────────┬─────────────────────────────┘
-                          │ download on first run / refresh
-                          ▼
-  ┌─────────────────────────────────────────────────────┐
-  │  LOCAL (documaris native app)                       │
-  │                                                     │
-  │  Local cache (documaris R2 snapshot)                │
-  │    vessels / voyages / cargo / events               │
-  │                             +                       │
-  │  User-provided crew JSON (PII — never leaves app)   │
-  │                             │                       │
-  │            documaris pipeline                       │
-  │   1. Data Fetch  (from local cache)                 │
-  │   2. Field Mapping                                  │
-  │   3. AI Fill  (local OSS model, bundled/downloaded) │
-  │   4. Trust Layer  (BLAKE3 + Ed25519, local key)     │
-  │   5. Regulatory Alert                               │
-  │   6. Render → PDF  (native PDF library)             │
-  │                             │                       │
-  │   ┌─────────────────────────┴──────────────────┐   │
-  │   ▼                                            ▼   │
-  │  PDF → local file system    Local audit log        │
-  │                             (append-only, tamper-  │
-  │                              evident; agent's own  │
-  │                              record, always avail) │
-  └───────────────────────────────┬─────────────────────┘
-                                  │ AuditRecord (no PII, no raw content)
-                                  │ queued locally if offline
-                                  ▼
-  ┌─────────────────────────────────────────────────────┐
-  │  REMOTE (tamper-proof audit store — append-only)    │
-  │  AuditRecord + payload synced via edgesentry-audit  │
-  │  store-and-forward. Storage backend under           │
-  │  evaluation (immugate / dedicated service).         │
-  │  Queryable by authorities and P&I Clubs.            │
-  └─────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    maridb["<b>REMOTE: maridb</b>\nvessel · voyage · cargo · events"]
+    r2["<b>REMOTE: documaris R2 bucket</b>\nread-only for app\nvessels / voyages / cargo / events (Parquet)"]
+    cache["Local cache\n(R2 snapshot)"]
+    crew["User-provided crew JSON\n⚠ PII — never leaves app"]
+    pipeline["<b>LOCAL: documaris native app</b>\n1. Data Fetch\n2. Field Mapping\n3. AI Fill (local OSS model)\n4. Trust Layer (BLAKE3 + Ed25519)\n5. Regulatory Alert\n6. Render → PDF"]
+    pdf["PDF\n→ local file system"]
+    local_log["<b>Local audit log</b>\nappend-only · tamper-evident\nagent's own record · always available"]
+    remote_store["<b>REMOTE: tamper-proof audit store</b>\nappend-only\nimmugate / dedicated service\nqueryable by authorities & P&I Clubs"]
+
+    maridb -->|"push — maridb copy job"| r2
+    r2 -->|"download on first run / refresh"| cache
+    cache --> pipeline
+    crew --> pipeline
+    pipeline --> pdf
+    pipeline -->|"AuditRecord\n(no PII, no raw content)"| local_log
+    local_log -.->|"edgesentry-audit store-and-forward\nqueued if offline"| remote_store
 ```
 
 ---
@@ -161,35 +132,20 @@ edgesentry-audit = { path = "../edgesentry-rs/crates/edgesentry-audit" }
 
 `edgesentry-audit` is an independent library. It knows nothing about vessels, voyages, documents, or AI fields. It receives opaque bytes and returns a sealed record. All maritime semantics live in documaris.
 
-```
-[documaris]  constructs DocumentAuditPayload (maritime-specific):
-               { vessel_id, voyage_id, doc_type,
-                 generated_by, generated_at,
-                 ai_field_values,        ← Class C only, no PII
-                 llm_confidence_flags,
-                 fields_modified,
-                 regulatory_alerts }
-             → serialize to bytes
+```mermaid
+flowchart TD
+    payload["<b>documaris</b> constructs DocumentAuditPayload\nvessel_id · voyage_id · doc_type\ngenerated_by · generated_at\nai_field_values · llm_confidence_flags\nfields_modified · regulatory_alerts\n<i>(Class C only — no PII)</i>"]
+    bytes["serialize → opaque bytes"]
+    seal["<b>edgesentry-audit</b>\nseal(payload_bytes, prev_hash, signing_key)\n<i>domain-agnostic — knows nothing about maritime fields</i>"]
+    record["AuditRecord\npayload_hash (BLAKE3)\nprev_record_hash\nsignature (Ed25519)\nseq · ts"]
+    xmp["hash embedded in\nPDF XMP /DocumentHash"]
+    local["<b>[1] LOCAL audit log</b>\nnative app · append-only\nwritten first · always available"]
+    remote["<b>[2] REMOTE audit store</b>\nimmugate · append-only\nqueryable by authorities"]
 
-[edgesentry-audit]  receives opaque bytes, knows nothing about their meaning:
-             seal(payload_bytes, prev_hash, signing_key)
-             → AuditRecord {
-                  payload_hash,      ← BLAKE3(payload_bytes)
-                  prev_record_hash,  ← hash chain link
-                  signature,         ← Ed25519 over the full record
-                  seq,               ← sequence number
-                  ts,                ← timestamp
-               }
-
-[documaris]  decides where to store (edgesentry-audit does not):
-             AuditRecord + payload_bytes
-               ├──→ [1] LOCAL — native app append-only store
-               │         Agent's own copy; always written first; available offline.
-               ├──→ hash hex embedded in PDF XMP metadata (/DocumentHash)
-               └──→ [2] REMOTE — tamper-proof cloud store (immugate under evaluation)
-                         Synced via edgesentry-audit store-and-forward.
-                         Queryable by authorities and P&I Clubs.
-                         Written when connectivity available; never blocks generation.
+    payload --> bytes --> seal --> record
+    record --> xmp
+    record --> local
+    local -.->|"store-and-forward\nqueued if offline"| remote
 ```
 
 **edgesentry-audit's public interface (simplified):**
@@ -234,14 +190,20 @@ documaris also auto-generates an **AIS Voyage Evidence Summary** companion docum
 
 At generation time, the AI fill layer cross-references the vessel snapshot against a per-port JSON regulatory knowledge base and returns a structured conflict list:
 
-```
-vessel_snapshot  +  port_regulatory_kb
-                          │
-                          ▼ LLM conflict check
-                          │
-               ── HIGH ───┼── block submission
-               ── MEDIUM ─┼── warn; Reviewer override with reason code, audit-logged
-               ── LOW ────┼── informational note in PDF cover sheet
+```mermaid
+flowchart LR
+    vessel["vessel snapshot"]
+    kb["port regulatory KB\n(JSON, per port)"]
+    llm["AI conflict check"]
+    high["🔴 HIGH\nblock submission"]
+    medium["🟡 MEDIUM\nwarn · reviewer override\nreason code · audit-logged"]
+    low["🟢 LOW\nnote in PDF cover sheet"]
+
+    vessel --> llm
+    kb --> llm
+    llm --> high
+    llm --> medium
+    llm --> low
 ```
 
 No hard-coded rule logic; the AI model evaluates natural-language rule descriptions against vessel data. The knowledge base is updated by a combination of automated port-notice monitoring and manual review.
@@ -256,27 +218,22 @@ This layer shifts documaris from "document automation tool" (commoditised) to **
 
 All forms — including those containing crew PII — are rendered inside the native app. There is no server-side rendering path and no split between PII and non-PII forms. The server-side / client-side duality that a browser-based approach required is eliminated.
 
-```
-vessel/voyage JSON (local cache)    crew JSON (user-provided, local only)
-              │                                    │
-              └─────────────────┬──────────────────┘
-                                ▼
-         Field map → Tera template → HTML → native PDF renderer
-                                ▼
-                     Trust Layer: BLAKE3 hash embedded in XMP
-                                 Ed25519 signature applied
-                                ▼
-                     PDF → local file system (Save dialog)
-                                │
-              ┌─────────────────┴──────────────────┐
-              ▼                                     ▼
-  [1] LOCAL audit log                   [2] REMOTE audit store
-  (native app, append-only)             (immugate / dedicated
-  Written immediately.                   service, append-only)
-  Agent's own tamper-evident            Queued if offline;
-  record; always available.             synced on reconnect
-                                        via edgesentry-audit
-                                        store-and-forward.
+```mermaid
+flowchart TD
+    vessel_json["vessel/voyage JSON\n(local cache)"]
+    crew_json["crew JSON\n(user-provided · local only)\n⚠ PII — never transmitted"]
+    render["Field map → Tera template\n→ HTML → native PDF renderer"]
+    trust["Trust Layer\nBLAKE3 hash in XMP · Ed25519 signature"]
+    pdf_out["PDF → local file system"]
+    local_log["<b>[1] LOCAL audit log</b>\nwritten immediately\nagent's own record"]
+    remote_store["<b>[2] REMOTE audit store</b>\nimmugate · append-only"]
+
+    vessel_json --> render
+    crew_json --> render
+    render --> trust
+    trust --> pdf_out
+    trust -->|"AuditRecord + payload_bytes"| local_log
+    local_log -.->|"edgesentry-audit\nstore-and-forward"| remote_store
 ```
 
 **Offline-first:** The entire pipeline — data fetch cache, AI fill model, PDF render, signing key, and local audit log write — runs without a network connection. A ship's steel engine room with no signal is a supported environment. The remote audit log sync is the only network-dependent step, and it is queued with store-and-forward (via edgesentry-audit) until connectivity resumes. The local audit log is always written first, so the agent's own tamper-evident record is available immediately regardless of connectivity.
@@ -324,7 +281,7 @@ The **Hanko-Confidence Score** (0.0–1.0) detects the presence, clarity, and te
 |---|---|---|---|---|
 | **Class A — PII** | Personal data directly identifying an individual | Crew name, passport number, date of birth, nationality | None — local processing only | 0 days — not stored by design |
 | **Class B — Sensitive** | Vessel compliance status and risk-relevant flags | Certificate validity, incident flags, DG declarations | Cloudflare R2 (maridb-controlled, access-logged) | Per maridb data policy |
-| **Class C — Operational** | Vessel/voyage/cargo metadata with no personal identifiers; AI-generated field values (non-PII) | IMO number, flag, GT, voyage dates, cargo HS codes, document hashes, AI-generated cargo description text, AI confidence scores per field | R2 + documaris audit log | Audit hashes: 365 days; generation logs: 180 days; error logs: 30 days (redacted) |
+| **Class C — Operational** | Vessel/voyage/cargo metadata with no personal identifiers; AI-generated field values (non-PII) | IMO number, flag, GT, voyage dates, cargo HS codes, document hashes, AI-generated cargo description text, AI confidence scores per field | maridb R2 (read by app) + immugate audit store (AuditRecord + DocumentAuditPayload) | Audit records: 365 days; generation logs: 180 days; error logs: 30 days (redacted) |
 
 ### Data flow boundary
 
@@ -340,19 +297,20 @@ REMOTE read (documaris R2 bucket, S3-compatible — read-only for app):
   └─ vessel/voyage/cargo Parquet — copied here by maridb; downloaded on
      first run and on refresh; no PII ever stored here
 
-REMOTE write (maridb audit log, append-only):
-  └─ BLAKE3 hash + Ed25519 signature + generation metadata
-     + AI-generated field values (Class C — no PII)
-     + field edit history (before/after for reviewer changes)
-     + llm_confidence per field + regulatory_alerts
-     (no crew PII; no raw PDF content; queued locally if offline)
+REMOTE write (tamper-proof audit store — immugate / dedicated service, append-only):
+  └─ AuditRecord (BLAKE3 hash, Ed25519 signature, seq, ts)
+     + DocumentAuditPayload (Class C — no PII, no raw PDF content)
+       vessel_id, voyage_id, doc_type, generated_by, generated_at,
+       ai_field_values, llm_confidence per field, fields_modified,
+       regulatory_alerts
+     (queued locally by edgesentry-audit store-and-forward if offline)
 ```
 
 ### Processing and storage rules
 
 - **Class A** is processed inside the native app only. It is never transmitted to any remote system. No network call contains Class A data — verifiable by code inspection.
 - **Class B / C** is downloaded from maridb R2 and processed locally inside the app. It is not re-uploaded to any documaris server.
-- The only remote write is the audit log entry: BLAKE3 hash + Ed25519 signature + generation metadata. No document content is stored remotely.
+- The only remote write is the AuditRecord + DocumentAuditPayload (Class C) to the tamper-proof audit store (immugate). No document content and no PII is stored remotely.
 
 ### Access control
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,14 +39,21 @@
   │   5. Regulatory Alert                               │
   │   6. Render → PDF  (native PDF library)             │
   │                             │                       │
-  │             PDF → local file system                 │
-  └─────────────────────────────┬───────────────────────┘
-                                │ hash only (no PII, no content)
-                                ▼
+  │   ┌─────────────────────────┴──────────────────┐   │
+  │   ▼                                            ▼   │
+  │  PDF → local file system    Local audit log        │
+  │                             (append-only, tamper-  │
+  │                              evident; agent's own  │
+  │                              record, always avail) │
+  └───────────────────────────────┬─────────────────────┘
+                                  │ AuditRecord (no PII, no raw content)
+                                  │ queued locally if offline
+                                  ▼
   ┌─────────────────────────────────────────────────────┐
   │  REMOTE (maridb audit log — append-only)            │
-  │  BLAKE3 hash + Ed25519 signature + generation meta  │
-  │  (queued locally if offline; synced on reconnect)   │
+  │  Same AuditRecord; synced via edgesentry-audit      │
+  │  store-and-forward. Queryable by authorities,       │
+  │  P&I Clubs, and agents for root cause analysis.     │
   └─────────────────────────────────────────────────────┘
 ```
 
@@ -149,21 +156,63 @@ Implemented by reusing **`edgesentry-audit`** — the shared Rust crate from `ed
 edgesentry-audit = { path = "../edgesentry-rs/crates/edgesentry-audit" }
 ```
 
-**Signing flow:**
+**Dual-copy append-only audit log — neither copy can be modified:**
+
+Every document generation event produces an `AuditRecord` that is written to two independent, append-only stores simultaneously. No raw document content or PII is stored in either — only the actions taken and the cryptographic fingerprints.
+
 ```
 PDF binary
     │
     ▼ compute_payload_hash(pdf_bytes)  → BLAKE3 Hash32
     │
-    ▼ sign_record(vessel_id, seq, ts, pdf_bytes, prev_hash, "fal_form_1", key_hex)
-    │  → AuditRecord { payload_hash, signature, prev_record_hash, … }
+    ▼ sign_record(vessel_id, seq, ts, prev_hash, doc_type, ai_field_values, key_hex)
+    │  → AuditRecord {
+    │       seq,                    ← sequence number (gaps detectable)
+    │       payload_hash,           ← BLAKE3 of final PDF
+    │       prev_record_hash,       ← hash of previous record (chain)
+    │       signature,              ← Ed25519 over the full record
+    │       generated_by,           ← user identity
+    │       generated_at,           ← ISO 8601 timestamp
+    │       vessel_id, voyage_id,   ← source data references (no raw data)
+    │       ai_field_values,        ← AI-generated text per field (Class C only, no PII)
+    │       llm_confidence_flags,   ← per-field confidence + reviewer action
+    │       fields_modified,        ← before/after for reviewer edits
+    │       regulatory_alerts,      ← alerts raised, severity, resolution
+    │    }
+    │
+    ├──→ [1] LOCAL audit log (native app, append-only SQLite/flat file)
+    │        Agent's own tamper-evident record; persists on their device.
+    │        Always written first; available immediately, even offline.
     │
     ├──→ hash hex embedded in PDF XMP metadata (/DocumentHash)
     │
-    └──→ AuditRecord written to maridb audit log (append-only)
+    └──→ [2] REMOTE audit log (maridb, append-only, cloud)
+             Synced via edgesentry-audit store-and-forward.
+             Queryable by authorities and P&I Clubs via verify endpoint.
+             Written when connectivity is available; never blocks generation.
 ```
 
-**Verification:** `GET /audit/verify?hash=<blake3_hex>` → `{ "verified": true, … }`
+**Tamper-evidence is structural, not policy:**
+- **Hash chain:** each record includes `prev_record_hash`. Inserting, modifying, or deleting any record breaks all subsequent hashes in the chain — detectable by any party holding a copy.
+- **Ed25519 signature:** each record is signed with the operator's key. Modifying a record breaks its signature.
+- **Dual copy:** the local log and the remote log can be cross-verified against each other. An attacker would need to compromise both simultaneously to suppress evidence.
+- **Sequence numbers:** gaps in the sequence are detectable — records cannot be silently dropped.
+
+**What the audit log records (no PII, full action trace):**
+
+| What happened | What's recorded |
+|---|---|
+| Document generated | who, when, which vessel/voyage (by ID), document type |
+| AI filled a field | what text was generated, confidence score |
+| Reviewer accepted a low-confidence field | that they accepted it, the confidence at the time |
+| Reviewer corrected a field | before value, after value, editor identity |
+| Regulatory alert raised | severity, rule triggered, resolution action |
+| MEDIUM alert overridden | reason code entered by reviewer, their identity |
+| Document hash embedded in PDF | the hash (not the document content) |
+
+**Root cause analysis:** agents and authorities can query either copy to reconstruct the exact sequence of actions that produced a document — without retrieving any crew PII. Whether a port rejection was caused by an AI error, a reviewer override, post-generation tampering, or a source data issue is answerable from the audit log alone.
+
+**Verification:** `GET /audit/verify?hash=<blake3_hex>` → `{ "verified": true, chain_intact: true, … }`
 
 documaris also auto-generates an **AIS Voyage Evidence Summary** companion document — a natural-language summary of the vessel's AIS track (departure port/time, transit, arrival, port stay duration), generated from maridb's AIS event Parquet data via the AI fill layer and signed with the same Ed25519 key as the primary document. This turns a form generator into a verifiable audit instrument: false declarations become detectable.
 
@@ -208,12 +257,18 @@ vessel/voyage JSON (local cache)    crew JSON (user-provided, local only)
                                  Ed25519 signature applied
                                 ▼
                      PDF → local file system (Save dialog)
-                                ▼
-                   hash + signature → maridb audit log
-                   (queued if offline; synced on reconnect)
+                                │
+              ┌─────────────────┴──────────────────┐
+              ▼                                     ▼
+  [1] LOCAL audit log                   [2] REMOTE audit log
+  (native app, append-only)             (maridb, append-only)
+  Written immediately.                  Queued if offline;
+  Agent's own tamper-evident            synced on reconnect
+  record; always available.             via edgesentry-audit
+                                        store-and-forward.
 ```
 
-**Offline-first:** The entire pipeline — data fetch cache, AI fill model, PDF render, and signing key — runs without a network connection. A ship's steel engine room with no signal is a supported environment. The audit log hash write is the only network-dependent step, and it is queued with store-and-forward (via edgesentry-audit) until connectivity resumes.
+**Offline-first:** The entire pipeline — data fetch cache, AI fill model, PDF render, signing key, and local audit log write — runs without a network connection. A ship's steel engine room with no signal is a supported environment. The remote audit log sync is the only network-dependent step, and it is queued with store-and-forward (via edgesentry-audit) until connectivity resumes. The local audit log is always written first, so the agent's own tamper-evident record is available immediately regardless of connectivity.
 
 **Privacy:** Because everything runs inside the native app process, there is no server-side code path at all for document generation. The privacy guarantee is structurally enforced, not a matter of configuration. Veson Nautical, ShipNet, and Helm CONNECT all require active server connectivity to render documents; documaris eliminates that dependency entirely.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,10 +50,11 @@
                                   │ queued locally if offline
                                   ▼
   ┌─────────────────────────────────────────────────────┐
-  │  REMOTE (maridb audit log — append-only)            │
-  │  Same AuditRecord; synced via edgesentry-audit      │
-  │  store-and-forward. Queryable by authorities,       │
-  │  P&I Clubs, and agents for root cause analysis.     │
+  │  REMOTE (tamper-proof audit store — append-only)    │
+  │  AuditRecord + payload synced via edgesentry-audit  │
+  │  store-and-forward. Storage backend under           │
+  │  evaluation (immugate / dedicated service).         │
+  │  Queryable by authorities and P&I Clubs.            │
   └─────────────────────────────────────────────────────┘
 ```
 
@@ -156,40 +157,49 @@ Implemented by reusing **`edgesentry-audit`** — the shared Rust crate from `ed
 edgesentry-audit = { path = "../edgesentry-rs/crates/edgesentry-audit" }
 ```
 
-**Dual-copy append-only audit log — neither copy can be modified:**
+**Responsibility boundary — edgesentry-audit is domain-agnostic:**
 
-Every document generation event produces an `AuditRecord` that is written to two independent, append-only stores simultaneously. No raw document content or PII is stored in either — only the actions taken and the cryptographic fingerprints.
+`edgesentry-audit` is an independent library. It knows nothing about vessels, voyages, documents, or AI fields. It receives opaque bytes and returns a sealed record. All maritime semantics live in documaris.
 
 ```
-PDF binary
-    │
-    ▼ compute_payload_hash(pdf_bytes)  → BLAKE3 Hash32
-    │
-    ▼ sign_record(vessel_id, seq, ts, prev_hash, doc_type, ai_field_values, key_hex)
-    │  → AuditRecord {
-    │       seq,                    ← sequence number (gaps detectable)
-    │       payload_hash,           ← BLAKE3 of final PDF
-    │       prev_record_hash,       ← hash of previous record (chain)
-    │       signature,              ← Ed25519 over the full record
-    │       generated_by,           ← user identity
-    │       generated_at,           ← ISO 8601 timestamp
-    │       vessel_id, voyage_id,   ← source data references (no raw data)
-    │       ai_field_values,        ← AI-generated text per field (Class C only, no PII)
-    │       llm_confidence_flags,   ← per-field confidence + reviewer action
-    │       fields_modified,        ← before/after for reviewer edits
-    │       regulatory_alerts,      ← alerts raised, severity, resolution
-    │    }
-    │
-    ├──→ [1] LOCAL audit log (native app, append-only SQLite/flat file)
-    │        Agent's own tamper-evident record; persists on their device.
-    │        Always written first; available immediately, even offline.
-    │
-    ├──→ hash hex embedded in PDF XMP metadata (/DocumentHash)
-    │
-    └──→ [2] REMOTE audit log (maridb, append-only, cloud)
-             Synced via edgesentry-audit store-and-forward.
-             Queryable by authorities and P&I Clubs via verify endpoint.
-             Written when connectivity is available; never blocks generation.
+[documaris]  constructs DocumentAuditPayload (maritime-specific):
+               { vessel_id, voyage_id, doc_type,
+                 generated_by, generated_at,
+                 ai_field_values,        ← Class C only, no PII
+                 llm_confidence_flags,
+                 fields_modified,
+                 regulatory_alerts }
+             → serialize to bytes
+
+[edgesentry-audit]  receives opaque bytes, knows nothing about their meaning:
+             seal(payload_bytes, prev_hash, signing_key)
+             → AuditRecord {
+                  payload_hash,      ← BLAKE3(payload_bytes)
+                  prev_record_hash,  ← hash chain link
+                  signature,         ← Ed25519 over the full record
+                  seq,               ← sequence number
+                  ts,                ← timestamp
+               }
+
+[documaris]  decides where to store (edgesentry-audit does not):
+             AuditRecord + payload_bytes
+               ├──→ [1] LOCAL — native app append-only store
+               │         Agent's own copy; always written first; available offline.
+               ├──→ hash hex embedded in PDF XMP metadata (/DocumentHash)
+               └──→ [2] REMOTE — tamper-proof cloud store (immugate under evaluation)
+                         Synced via edgesentry-audit store-and-forward.
+                         Queryable by authorities and P&I Clubs.
+                         Written when connectivity available; never blocks generation.
+```
+
+**edgesentry-audit's public interface (simplified):**
+```rust
+// All documaris-specific fields are in the opaque payload_bytes.
+// edgesentry-audit seals whatever bytes it receives.
+fn seal(payload_bytes: &[u8], prev_hash: Hash32, key: &SigningKey) -> AuditRecord;
+fn verify(record: &AuditRecord, payload_bytes: &[u8]) -> bool;
+// store-and-forward: knows only the endpoint URL, not the payload semantics
+fn queue_and_sync(record: AuditRecord, payload_bytes: Vec<u8>, endpoint: &Url);
 ```
 
 **Tamper-evidence is structural, not policy:**
@@ -212,9 +222,9 @@ PDF binary
 
 **Root cause analysis:** agents and authorities can query either copy to reconstruct the exact sequence of actions that produced a document — without retrieving any crew PII. Whether a port rejection was caused by an AI error, a reviewer override, post-generation tampering, or a source data issue is answerable from the audit log alone.
 
-**Verification:** `GET /audit/verify?hash=<blake3_hex>` → `{ "verified": true, chain_intact: true, … }`
+**Verification:** `GET /audit/verify?hash=<blake3_hex>` → `{ "verified": true, chain_intact: true, … }` — served by the remote audit store, independent of documaris.
 
-documaris also auto-generates an **AIS Voyage Evidence Summary** companion document — a natural-language summary of the vessel's AIS track (departure port/time, transit, arrival, port stay duration), generated from maridb's AIS event Parquet data via the AI fill layer and signed with the same Ed25519 key as the primary document. This turns a form generator into a verifiable audit instrument: false declarations become detectable.
+documaris also auto-generates an **AIS Voyage Evidence Summary** companion document — a natural-language summary of the vessel's AIS track (departure port/time, transit, arrival, port stay duration), generated from maridb's AIS event Parquet data via the AI fill layer. The summary is treated as a payload and sealed by edgesentry-audit identically to any other document — the library does not distinguish it from a FAL form. This turns a form generator into a verifiable audit instrument: false declarations become detectable.
 
 **TrustSG / IMDA alignment:** the Trust Layer directly addresses two TrustSG pillars — Authenticity (Ed25519 signature proves the document originated from verified vessel data) and Integrity (BLAKE3 hash + append-only audit log proves no post-generation modification). This positions documaris as national-grade trust infrastructure for maritime document exchange, not a convenience tool.
 
@@ -260,11 +270,12 @@ vessel/voyage JSON (local cache)    crew JSON (user-provided, local only)
                                 │
               ┌─────────────────┴──────────────────┐
               ▼                                     ▼
-  [1] LOCAL audit log                   [2] REMOTE audit log
-  (native app, append-only)             (maridb, append-only)
-  Written immediately.                  Queued if offline;
-  Agent's own tamper-evident            synced on reconnect
-  record; always available.             via edgesentry-audit
+  [1] LOCAL audit log                   [2] REMOTE audit store
+  (native app, append-only)             (immugate / dedicated
+  Written immediately.                   service, append-only)
+  Agent's own tamper-evident            Queued if offline;
+  record; always available.             synced on reconnect
+                                        via edgesentry-audit
                                         store-and-forward.
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ flowchart TD
     pipeline["<b>LOCAL: documaris native app</b>\n1. Data Fetch\n2. Field Mapping\n3. AI Fill (local OSS model)\n4. Trust Layer (BLAKE3 + Ed25519)\n5. Regulatory Alert\n6. Render → PDF"]
     pdf["PDF\n→ local file system"]
     local_log["<b>Local audit log</b>\nappend-only · tamper-evident\nagent's own record · always available"]
-    remote_store["<b>REMOTE: tamper-proof audit store</b>\nappend-only\nimmugate / dedicated service\nqueryable by authorities & P&I Clubs"]
+    remote_store["<b>REMOTE: tamper-proof audit store</b>\nappend-only\nappend-only R2 bucket (MVP) → immugate (future)\nqueryable by authorities & P&I Clubs"]
 
     maridb -->|"push — maridb copy job"| r2
     r2 -->|"download on first run / refresh"| cache
@@ -128,6 +128,12 @@ Implemented by reusing **`edgesentry-audit`** — the shared Rust crate from `ed
 edgesentry-audit = { path = "../edgesentry-rs/crates/edgesentry-audit" }
 ```
 
+**Remote audit store — MVP and future:**
+
+> **MVP:** an append-only Cloudflare R2 bucket. Tamper-evidence comes from the hash chain and Ed25519 signatures produced by edgesentry-audit — not from R2's storage guarantees. The bucket is write-only (no DELETE, no overwrite); any modification to a stored record breaks the chain and is detectable.
+>
+> **Future:** **immugate** — a commercial service to be built by this team, providing a dedicated tamper-proof audit log with a public Merkle-tree verification API. immugate is not yet built; the R2 bucket is the production interim. The store-and-forward endpoint in edgesentry-audit is the only change needed when immugate ships.
+
 **Responsibility boundary — edgesentry-audit is domain-agnostic:**
 
 `edgesentry-audit` is an independent library. It knows nothing about vessels, voyages, documents, or AI fields. It receives opaque bytes and returns a sealed record. All maritime semantics live in documaris.
@@ -140,7 +146,7 @@ flowchart TD
     record["AuditRecord\npayload_hash (BLAKE3)\nprev_record_hash\nsignature (Ed25519)\nseq · ts"]
     xmp["hash embedded in\nPDF XMP /DocumentHash"]
     local["<b>[1] LOCAL audit log</b>\nnative app · append-only\nwritten first · always available"]
-    remote["<b>[2] REMOTE audit store</b>\nimmugate · append-only\nqueryable by authorities"]
+    remote["<b>[2] REMOTE audit store</b>\nappend-only R2 bucket (MVP)\nimmugate · future commercial service"]
 
     payload --> bytes --> seal --> record
     record --> xmp
@@ -226,7 +232,7 @@ flowchart TD
     trust["Trust Layer\nBLAKE3 hash in XMP · Ed25519 signature"]
     pdf_out["PDF → local file system"]
     local_log["<b>[1] LOCAL audit log</b>\nwritten immediately\nagent's own record"]
-    remote_store["<b>[2] REMOTE audit store</b>\nimmugate · append-only"]
+    remote_store["<b>[2] REMOTE audit store</b>\nappend-only R2 bucket (MVP)\nimmugate · future"]
 
     vessel_json --> render
     crew_json --> render
@@ -281,7 +287,7 @@ The **Hanko-Confidence Score** (0.0–1.0) detects the presence, clarity, and te
 |---|---|---|---|---|
 | **Class A — PII** | Personal data directly identifying an individual | Crew name, passport number, date of birth, nationality | None — local processing only | 0 days — not stored by design |
 | **Class B — Sensitive** | Vessel compliance status and risk-relevant flags | Certificate validity, incident flags, DG declarations | Cloudflare R2 (maridb-controlled, access-logged) | Per maridb data policy |
-| **Class C — Operational** | Vessel/voyage/cargo metadata with no personal identifiers; AI-generated field values (non-PII) | IMO number, flag, GT, voyage dates, cargo HS codes, document hashes, AI-generated cargo description text, AI confidence scores per field | maridb R2 (read by app) + immugate audit store (AuditRecord + DocumentAuditPayload) | Audit records: 365 days; generation logs: 180 days; error logs: 30 days (redacted) |
+| **Class C — Operational** | Vessel/voyage/cargo metadata with no personal identifiers; AI-generated field values (non-PII) | IMO number, flag, GT, voyage dates, cargo HS codes, document hashes, AI-generated cargo description text, AI confidence scores per field | maridb R2 (read by app) + append-only R2 audit bucket (AuditRecord + DocumentAuditPayload); immugate in future | Audit records: 365 days; generation logs: 180 days; error logs: 30 days (redacted) |
 
 ### Data flow boundary
 
@@ -297,7 +303,7 @@ REMOTE read (documaris R2 bucket, S3-compatible — read-only for app):
   └─ vessel/voyage/cargo Parquet — copied here by maridb; downloaded on
      first run and on refresh; no PII ever stored here
 
-REMOTE write (tamper-proof audit store — immugate / dedicated service, append-only):
+REMOTE write (tamper-proof audit store — append-only R2 bucket (MVP) → immugate (future), append-only):
   └─ AuditRecord (BLAKE3 hash, Ed25519 signature, seq, ts)
      + DocumentAuditPayload (Class C — no PII, no raw PDF content)
        vessel_id, voyage_id, doc_type, generated_by, generated_at,
@@ -310,7 +316,7 @@ REMOTE write (tamper-proof audit store — immugate / dedicated service, append-
 
 - **Class A** is processed inside the native app only. It is never transmitted to any remote system. No network call contains Class A data — verifiable by code inspection.
 - **Class B / C** is downloaded from maridb R2 and processed locally inside the app. It is not re-uploaded to any documaris server.
-- The only remote write is the AuditRecord + DocumentAuditPayload (Class C) to the tamper-proof audit store (immugate). No document content and no PII is stored remotely.
+- The only remote write is the AuditRecord + DocumentAuditPayload (Class C) to the tamper-proof audit store (append-only R2 bucket, MVP). No document content and no PII is stored remotely.
 
 ### Access control
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -256,9 +256,9 @@ The **Hanko-Confidence Score** (0.0–1.0) detects the presence, clarity, and te
 
 | Class | Contents | Examples | Server storage | Retention |
 |---|---|---|---|---|
-| **Class A — PII** | Personal data directly identifying an individual | Crew name, passport number, date of birth | None — local processing only | 0 days — not stored by design |
+| **Class A — PII** | Personal data directly identifying an individual | Crew name, passport number, date of birth, nationality | None — local processing only | 0 days — not stored by design |
 | **Class B — Sensitive** | Vessel compliance status and risk-relevant flags | Certificate validity, incident flags, DG declarations | Cloudflare R2 (maridb-controlled, access-logged) | Per maridb data policy |
-| **Class C — Operational** | Vessel/voyage/cargo metadata with no personal identifiers | IMO number, flag, GT, voyage dates, cargo HS codes, document hashes | R2 + documaris audit log | Audit hashes: 365 days; generation logs: 180 days; error logs: 30 days (redacted) |
+| **Class C — Operational** | Vessel/voyage/cargo metadata with no personal identifiers; AI-generated field values (non-PII) | IMO number, flag, GT, voyage dates, cargo HS codes, document hashes, AI-generated cargo description text, AI confidence scores per field | R2 + documaris audit log | Audit hashes: 365 days; generation logs: 180 days; error logs: 30 days (redacted) |
 
 ### Data flow boundary
 
@@ -276,7 +276,10 @@ REMOTE read (documaris R2 bucket, S3-compatible — read-only for app):
 
 REMOTE write (maridb audit log, append-only):
   └─ BLAKE3 hash + Ed25519 signature + generation metadata
-     (no document content; no PII; queued locally if offline)
+     + AI-generated field values (Class C — no PII)
+     + field edit history (before/after for reviewer changes)
+     + llm_confidence per field + regulatory_alerts
+     (no crew PII; no raw PDF content; queued locally if offline)
 ```
 
 ### Processing and storage rules
@@ -315,17 +318,21 @@ All document-generation events and manual field edits are audit-logged with role
 
 ### Audit trail per document
 
-Every generated document records the following in the maridb append-only audit log:
+Every generated document records the following in the maridb append-only audit log. No Class A (PII) data is included — crew names, passport numbers, and personal identifiers are never written to the log. All entries are Class C (operational) and support root cause analysis of submission errors and disputes without storing any personal data.
 
-| Field | Value |
-|---|---|
-| `generated_by` | User identity |
-| `generated_at` | ISO 8601 timestamp |
-| `fields_modified` | Field names edited in human review step, with before/after values and editor identity |
-| `llm_confidence_flags` | Fields that triggered confidence < 0.80 warning and how they were resolved |
-| `regulatory_alerts` | Alerts raised, severity, and resolution action |
-| `audit_hash` | BLAKE3 hash of final PDF binary |
-| `signature` | Ed25519 signature |
+| Field | Value | Root cause use |
+|---|---|---|
+| `generated_by` | User identity | Who ran the generation |
+| `generated_at` | ISO 8601 timestamp | When — cross-reference with port rejection timestamp |
+| `vessel_id` / `voyage_id` | maridb source references | Which data snapshot was used; look up in maridb for the exact values at generation time |
+| `audit_hash` | BLAKE3 hash of final PDF binary | Was the submitted PDF the same as the generated PDF? Hash mismatch = tampered after generation |
+| `signature` | Ed25519 signature | Is the document authentic — from a valid documaris instance? |
+| `ai_field_values` | AI-generated text per field (Class C only — no PII fields included) | What exactly did the AI write? Cross-check against source data to identify AI summarisation errors |
+| `llm_confidence_flags` | Per-field confidence score; whether reviewer accepted or corrected | Which fields were uncertain; did the reviewer override a low-confidence output without correcting it? |
+| `fields_modified` | Field names edited in human review step, before/after values, editor identity | Was the submitted content what the AI generated, or did a reviewer change it? |
+| `regulatory_alerts` | Alerts raised, severity, resolution action, reason code | Were compliance warnings present? Were MEDIUM alerts overridden and why? |
+
+**Root cause analysis scenario:** a port authority rejects FAL Form 1 because the cargo description doesn't match the manifest. The agent queries `GET /audit/verify?hash=<blake3_hex>` and finds: `brief_cargo_description` was AI-generated at confidence 0.73 (below 0.80 → amber flag shown); the reviewer accepted without correction; the AI wrote "containerised electronics" while the maridb source (`voyage_id=V20260424`) recorded "2,400 units mobile phones". Root cause identified without storing any crew PII: AI produced a low-confidence summary and the reviewer did not verify it.
 
 Retrievable via `GET /audit/verify?hash=<blake3_hex>`.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # documaris — Roadmap
 
-- **Date:** 2026-04-26 (updated from 2026-04-24)
+- **Date:** 2026-04-26 (updated from 2026-04-26)
 - **Status:** Core design defined; R2 schema contract and PII boundary pending sign-off
 - **Delivery:** Native desktop app; local open-source AI model (Apache 2.0 / MIT, model TBD)
 - **PIER71 application deadline:** 15 June 2026
@@ -9,130 +9,188 @@
 
 ---
 
+## PIER71 demo scenarios
+
+The PIER71 demo is built around four test cases demonstrated in sequence as a single unscripted walkthrough. Each test case maps directly to the core value proposition.
+
+| # | Test case | What it proves | Milestone gate |
+|---|---|---|---|
+| **TC1** | One-click generation from structured data | Automation — the manual re-entry problem is solved | M2 |
+| **TC2** | Regulatory alert blocks a non-compliant submission | Compliance checking before submission, not after rejection | M3 |
+| **TC3** | Low-confidence AI field triggers human review | Human Agency & Oversight — AI proposes, human decides (AI Verify alignment) | M2 |
+| **TC4** | Agent traces an error in the audit log | Post-incident traceability — who did what, what the AI wrote, what the reviewer decided | M2 |
+
+**Demo flow (TC1 → TC3 → TC2 → TC4):**
+```
+TC1: "Here is how a full port call package is generated in one click."
+  ↓
+TC3: "When the AI is uncertain, the system stops and asks the agent to check."
+  ↓
+TC2: "When a compliance rule is violated, generation is blocked before submission."
+  ↓
+TC4: "If a question arises after submission, the agent can trace exactly what happened."
+```
+
+**Deferred to POST PIER71:**
+- TC5 (offline operation) — differentiator but adds demo complexity; deferred
+- AIS Voyage Evidence — narrative value but not required for TC1–TC4
+- PoC full measurement (20 cases) → 5 representative cases at M3 is sufficient for the application
+- Remote audit store sync (R2 audit bucket) — local audit log is sufficient for the demo
+- Model bundling / distribution strategy — ship it working; packaging is post-PIER71
+
+---
+
 ## Sprint milestones (6–7 weeks to PIER71 submission)
 
-**Demo principle:** a working build of the native app is available from M1 onwards and progressively enriched at each milestone. Every milestone produces something runnable. There is no "build first, demo later" phase — each week's output is demonstrable. For PIER71, the demo is a downloadable macOS build (or a screen recording if evaluators cannot run the app directly).
+**Build principle:** every milestone produces something runnable. No "build first, demo later." From M1 onwards the native app is progressively enriched. For PIER71, the demo is a downloadable macOS build or a screen recording.
 
 ---
 
-### Milestone 0 — Schema contract + native app skeleton (Week 1)
+### Milestone 0 — Decision sprint + skeleton (Week 1)
 
-**Deliverables:** `mock/vessel_V001.json` + `field_maps/fal_form_1_field_map.json` + runnable native app skeleton (window opens, loads mock data)
+**Gate:** three hard decisions made; skeleton runs.
 
-- Select native app framework and local AI model (decisions needed before M1 pipeline can be wired up)
-- Define a single vessel + voyage + cargo mock record matching the maridb DuckLake Parquet schema
-- Map every FAL Form 1 field to its maridb source, fill type, and AI-fill-required flag
-- Cross-check every field against IMO FAL Convention Annex for completeness
-- Agree schema for the documaris R2 bucket with maridb (schema contract: which fields, which Parquet partition layout); this is the interface contract for maridb's copy job — maridb's own R2 output is not modified; confirm crew PII is explicitly excluded from the documaris bucket
-- Confirm model download / bundling strategy: size budget, first-run UX, storage location
+**Decisions (must be made this week — everything else blocks on these):**
 
----
+| Decision | Options | Blocking |
+|---|---|---|
+| Native app framework | Tauri (Rust/WebView) · egui · iced | M1 UI wiring |
+| Local AI model | Apache 2.0 / MIT model with JP support + structured JSON output | M1 AI fill |
+| R2 schema contract | Parquet partition layout agreed with maridb | M1 field map + maridb#49 copy job |
 
-### Milestone 1 — FAL Form 1 template + pipeline (Week 2)
-
-**Demo state after this milestone:** native app shows "Generate FAL Form 1" button → PDF saved to local file system in < 1 second from mock data.
-
-#### Must (milestone gate)
-- `templates/fal/fal_form_1.html` — A4, pixel-accurate against the official IMO FAL Form 1 PDF
-- Native app pipeline wired end-to-end: button click → mock Parquet → DuckDB → field map → AI fill → Tera → native PDF render → local file save
-
-#### Should (target if template is confirmed correct by mid-week)
-- FAL Form 5 path: user selects local crew JSON file → merged with vessel/voyage data → PDF rendered locally (all PII stays in app process)
-
-#### Could (stretch — carry to M2 if needed)
-- Offline mode confirmed: disconnect network → all generation still works from local cache
+**Deliverables:**
+- `mock/vessel_V001.json` — single vessel + voyage + cargo record matching agreed schema
+- `field_maps/fal_form_1_field_map.json` — every FAL Form 1 field mapped to maridb source, fill type, AI-fill flag
+- Native app skeleton: window opens, loads mock data, no crash
+- Crew PII exclusion from documaris R2 bucket confirmed in maridb pipeline spec
 
 ---
 
-### Milestone 2 — FAL Form 5 + Trust Layer + AIS Evidence (Week 3)
+### Milestone 1 — FAL Form 1 pipeline (Week 2)
 
-**Demo state after this milestone:** native app generates a full port call package (FAL 1 + FAL 5 + AIS Evidence); each PDF displays its BLAKE3 hash; `documaris verify <pdf>` confirms authenticity in < 1 second.
+**Demo state:** "Generate FAL Form 1" button → PDF on local file system in < 1 second from mock data.
 
-**Deliverables:** Port call package (FAL 1 + FAL 5 + AIS Voyage Evidence) sharing one integrity hash; `documaris verify <pdf>` CLI; AuditRecord entry visible in append-only R2 audit bucket
+#### Must
+- `templates/fal/fal_form_1.html` — A4, pixel-accurate against IMO FAL Form 1
+- End-to-end: button → mock Parquet → DuckDB → field map → AI fill → Tera → PDF render → local save
+
+#### Should
+- FAL Form 5 path: user selects local crew JSON → merged with vessel/voyage → PDF rendered locally (PII stays in app process)
+
+#### Could (carry to M2 if needed)
+- Offline mode: disconnect network → generation still works from local cache
+
+---
+
+### Milestone 2 — Trust Layer + confidence gate + audit trace (Week 3)
+
+**Demo gate: TC1 + TC3 + TC4 all demonstrable from this milestone.**
+
+**TC1 demo state:** FAL 1 + FAL 5 package generated in one click; BLAKE3 hash visible on each PDF.
+
+**TC3 demo state:** vessel with a vague cargo entry → `brief_cargo_description` field shows amber flag (confidence < 0.80) → export blocked → reviewer confirms or corrects → export proceeds.
+
+**TC4 demo state:** `documaris verify <pdf>` returns the full audit trace — what the AI wrote, confidence score, whether the reviewer accepted or corrected, timestamp — in human-readable form.
+
+**Deliverables:**
 
 - FAL Form 5 field map (variable crew size)
 - Multi-document output: `documaris generate port-call-package --vessel <id>`
-- Trust Layer: `edgesentry-audit` path dep; BLAKE3 hash on PDF output; hash embedded in XMP metadata; `DocumentAuditPayload` serialised → `edgesentry-audit` seal → `AuditRecord` written to local audit log + synced to append-only R2 audit bucket
-- AIS Voyage Evidence: DuckDB query on maridb R2 AIS events → AI fill natural-language voyage summary → signed companion document appended to the package
+- **Trust Layer:**
+  - `edgesentry-audit` path dep; BLAKE3 hash on PDF; hash embedded in XMP `/DocumentHash`
+  - `DocumentAuditPayload` constructed by documaris (vessel_id, voyage_id, ai_field_values, llm_confidence_flags, fields_modified) → serialised → `edgesentry-audit` `seal(bytes)` → `AuditRecord`
+  - `AuditRecord` + payload written to local append-only audit log (always, immediately)
+- **Confidence gate UI:**
+  - Fields with confidence < 0.80 → amber flag in review UI → PDF export blocked
+  - Reviewer must explicitly accept or correct each flagged field
+  - Decision recorded in `llm_confidence_flags`
+- **`documaris verify <pdf>` CLI:**
+  - Reads hash from PDF XMP → queries local audit log → returns human-readable trace
+  - Output shows: AI-generated value, confidence, reviewer action, timestamp, source data references
+
+> **AIS Voyage Evidence deferred.** Adds narrative value but is not required for TC1–TC4. Moved to POST PIER71.
 
 ---
 
-### Milestone 3 — Singapore package + Regulatory Alert + PoC measurement (Week 4)
+### Milestone 3 — Singapore package + Regulatory Alert (Week 4)
 
-**Demo state after this milestone:** native app adds "Singapore port entry package" button; a pre-loaded non-compliant vessel triggers a visible HIGH alert that blocks the generate button. PoC KPI report published.
+**Demo gate: TC2 demonstrable from this milestone.**
 
-**Deliverables:** `singapore_port_entry_field_map.json` + Regulatory Alert demo on a deliberately non-compliant vessel + PoC KPI report + subscription pricing model draft
+**TC2 demo state:** vessel with expired BWM D-2 certificate → Singapore package → HIGH alert fires → generate button blocked. A compliant vessel generates cleanly.
 
-- Collect MPA Port+ and TradeNet form templates; map fields to maridb schema
-- Build seed regulatory knowledge base for Port of Singapore (BWM D-2, quarantine windows, DG restrictions)
-- Implement Regulatory Alert: AI conflict-check at generation time; HIGH/MEDIUM/LOW severity; HIGH blocks submission; conflicts surfaced in PDF cover sheet
-- Demo: expired BWM certificate vessel → HIGH alert triggered
-- **PoC measurement (20 sample Singapore port call cases):**
-  - Average document creation time: baseline 32 min → target 14 min (56% reduction)
-  - Port-authority rework / rejection rate: baseline 18% → target 9% (50% reduction)
-  - Regulatory Alert precision: fraction of HIGH alerts that correspond to a real compliance rule violation (target ≥ 90%)
-  - Results published as `poc/singapore_kpi_report.md`
-- Identify MPA-connected pilot candidate via PIER71 programme (name + role confirmed)
+**Deliverables:**
 
-> **Customer validation dependency:** The baseline figures (32 min, 18%) are stated as hypotheses derived from informal ship agent interviews. M3 is the first milestone where these are measured against real port call cases. If baselines differ materially from the hypotheses, PoC targets will be revised and the delta disclosed in the KPI report. See [`customers.md`](customers.md) for the full list of unvalidated assumptions.
+- `singapore_port_entry_field_map.json` — MPA Port+ aligned fields mapped to maridb schema
+- Regulatory KB seed — at least 5 real Port of Singapore rules (BWM D-2, quarantine pre-notification window, DG restrictions, crew document minimum validity periods)
+- Regulatory Alert implementation: AI conflict-check at generation time; HIGH/MEDIUM/LOW severity; HIGH blocks export; alert detail surfaced in PDF cover sheet; MEDIUM override requires reason code (audit-logged)
+- Demo vessel: deliberately non-compliant record with expired BWM certificate
+- **PoC measurement (5 representative Singapore port call cases):**
+  - Document creation time: baseline ~32 min → target < 14 min
+  - Regulatory Alert precision: HIGH alerts matching real violations → target ≥ 90%
+  - Results in `poc/singapore_kpi_report.md`
+- MPA-connected pilot candidate identified (name + role)
 
----
-
-### Milestone 4 — Singapore polish + demo prep (Week 5)
-
-**Demo state after this milestone:** native app is demo-ready — realistic vessel data, offline mode confirmed, all four differentiators exercisable in a single unscripted walkthrough.
-
-**Deliverables:** End-to-end Singapore package demo on a real or realistic vessel record; all four differentiators exercisable in one flow
-
-- Polish Singapore field map against actual MPA Port+ form samples; resolve any field mapping gaps
-- Extend regulatory KB with at least 5 real Port of Singapore rules (validate against recent MPA circulars)
-- Harden the Trust Layer verify endpoint; ensure `documaris verify <pdf>` returns a human-readable result suitable for showing to a port officer
-- Offline demo (carry from M1 Could): confirm FAL Form 5 generates with no network and hash syncs on reconnect
-- Confirm pilot engagement with identified M3 contact: secure a meeting or letter of intent
+> **PoC scale reduced from 20 to 5 cases.** 5 real cases with honest KPI reporting is sufficient for the PIER71 application at this stage. If baselines differ from hypotheses, delta is disclosed in the report.
 
 ---
 
-### Milestone 5 — PIER71 submission polish (Weeks 6–7)
+### Milestone 4 — Demo hardening (Week 5)
 
-**Demo state:** native app already running since M1; this milestone polishes presentation, records the screen capture, and finalises the application text. No last-minute scramble.
+**Gate: TC1 → TC3 → TC2 → TC4 run end-to-end, unscripted, without error.**
 
-**Deliverables:** 2-minute screen recording of the native app demo + PIER71 application draft ready for submission (deadline: 15 June 2026)
+This milestone adds no new features. The entire week is spent making the four-TC demo reliable and recordable.
 
-The native app already demonstrates all four differentiators from M1. M5 work is polish and narrative, not new features:
+- Run TC1–TC4 in sequence on a realistic (not mock) vessel record
+- Harden `documaris verify <pdf>` output to be readable by a non-technical reviewer
+- Resolve any field mapping gaps against actual MPA Port+ form samples
+- Validate regulatory KB rules against recent MPA Port Marine Circulars
+- Confirm pilot engagement with M3 contact: meeting or letter of intent
+- Prepare demo script (narrative, not clicks) aligned to business brief sections
 
-1. **Data → Documents** — maridb R2 data + local crew JSON → one click → FAL 1 + FAL 5 + Singapore package + AIS Evidence; PDF saved locally
-2. **Verifiable Audit Trail** — hash shown post-generation; `verify` endpoint confirms document against AIS voyage record in < 1 second
-3. **Regulatory Alert** — non-compliant vessel (expired BWM certificate) triggers HIGH alert on Singapore package, blocking generation
-4. **Offline-First** — disconnect network → FAL Form 5 from local cache in < 10 seconds; hash queued and synced on reconnect
+---
 
-Polish PDF output to IMO layout standard. Prepare PIER71 application text.
+### Milestone 5 — PIER71 submission (Weeks 6–7)
+
+**Gate: 2-minute screen recording complete; application text submitted by 15 June 2026.**
+
+The demo already runs. M5 is recording and narrative — no new code.
+
+**Demo recording structure (2 minutes):**
+
+1. **(TC1 — 30 sec)** Load a Singapore-bound vessel. Click generate. FAL 1 + FAL 5 + Singapore package appear. BLAKE3 hash visible on each PDF.
+2. **(TC3 — 30 sec)** Point to the amber-flagged cargo description field. Show the confidence score. Reviewer corrects and confirms. Export proceeds.
+3. **(TC2 — 30 sec)** Switch to a vessel with an expired BWM certificate. Click generate. HIGH alert fires. Export blocked. Show the compliance rule triggered.
+4. **(TC4 — 30 sec)** Run `documaris verify <pdf>` on the document from TC1. Show the audit trace: AI wrote X at confidence 0.73, reviewer accepted, timestamp, source vessel_id.
+
+**Deliverables:**
+- 2-minute screen recording (above structure)
+- PIER71 application form text (from `pier71-business-brief.md` submission-ready section)
+- Slide deck aligned to 15-slide structure in `pier71-evaluation-mapping.md`
 
 ---
 
 ## Phase roadmap (beyond PIER71)
 
-| Phase | Milestone | Products |
+| Phase | Focus | New capabilities |
 |---|---|---|
-| 1 — PIER71 MVP (now) | FAL Form 1 + FAL Form 5 (OSS) + Singapore package; PIER71 demo build | maridb + documaris |
-| 2 — Private entity | First paying Singapore ship agent or operator; Japan package + Reverse Ingestion / Hanko-Confidence Score | maridb + documaris |
-| 3 — Hardware partner | Integrate hardware partner (connectivity or onboard ERP vendor) to enrich maridb data | maridb + documaris + partner hardware |
-| 4 — Full solution | edgesentry physical inspection layer feeds maridb → documaris reporting loop; inspection reports part of port call package | maridb + arktrace + documaris + edgesentry |
+| **1 — PIER71 MVP** | TC1–TC4 demo; Singapore pilot | FAL 1 + FAL 5 + Singapore package; local audit log |
+| **2 — Pilot-ready** | First paying Singapore agent/operator | AIS Voyage Evidence; TC5 offline mode; remote R2 audit bucket sync; Japan package; unstructured ingestion (email/messaging secondary path); TradeTrust Phase 2 |
+| **3 — Commercial** | Japan expansion + PIER71-02 PoC | edgesentry-audit extended to shipboard OT; Hanko-Confidence Score (OCR); maridb expanded with engine/sensor logs; immugate commercial audit service |
+| **4 — Platform** | Full trust platform | edgesentry + arktrace + documaris unified; PIER71-12 sensor data verification |
 
 ---
 
 ## Open questions
 
-1. **R2 partition layout contract** — needs agreement between maridb and documaris before M0; documaris field maps depend on this schema; maridb's current R2 layout (MMSI-based watchlist data) differs from the vessel/voyage/cargo document model required — maridb must implement the new layout
-2. **Crew PII exclusion from R2** — needs an explicit maridb pipeline rule; if any PII lands in R2 Parquet files, the local-processing privacy boundary breaks
-3. **Audit log location in maridb** — documaris writes AuditRecords to maridb's append-only log; the schema and table location for document audit records within maridb need to be agreed as part of the M0 schema contract
-4. **DuckDB `bundled` compile time** — adds ~2 min to CI builds and ~10 MB to binary; acceptable for prototype; evaluate system DuckDB for production CI
-5. **Native app framework** — Tauri (Rust/WebView) vs. pure Rust TUI/GUI (egui, iced) vs. other; decision needed before M0 skeleton; affects UI development speed and distribution packaging
-6. **AI model selection** — permissively licensed (Apache 2.0 / MIT) model with Japanese support and structured JSON output; must fit in acceptable download size budget; decision needed before M1 pipeline is finalised
-7. **Model distribution** — bundled in installer vs. downloaded on first run; size budget for macOS .dmg; storage location (app bundle vs. user data dir)
-8. **Regulatory KB update ownership** — automated port-notice scraping introduces hallucination risk; manual review gate needed; who owns this operationally?
-9. **Japan OCR / Hanko (Phase 2)** — deferred from PIER71 MVP; requires a local vision-capable model; selection and accuracy on Hakata Port samples to be validated before Phase 2 build begins
+1. **R2 schema contract** — partition layout must be agreed with maridb before M0 closes; maridb copy job (maridb#49) depends on this
+2. **Crew PII exclusion from R2** — explicit maridb pipeline rule needed; if any PII lands in Parquet files the local-processing boundary breaks
+3. **Native app framework** — Tauri vs. egui vs. iced; decision needed Day 1 of W1
+4. **AI model selection** — Apache 2.0 / MIT; Japanese support; structured JSON output; size budget for installer; decision needed before M1 AI fill is wired
+5. **Model distribution** — bundled vs. downloaded on first run; size budget for macOS .dmg
+6. **Audit log location (open Q removed)** — no longer maridb; local append-only file in native app (always), R2 audit bucket (Phase 2)
+7. **Regulatory KB update ownership** — manual review gate needed for port-notice scraping; who owns this operationally?
+8. **Japan OCR / Hanko (Phase 2)** — deferred; local vision-capable model required; validate on Hakata Port samples before Phase 2 build
 
 ---
 
 *See also: [`background.md`](background.md) · [`architecture.md`](architecture.md)*
-*Full use case specifications and prototype stack decisions: `_outputs/document-generation-plan.md`*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,20 +46,20 @@
 
 ### Milestone 2 — FAL Form 5 + Trust Layer + AIS Evidence (Week 3)
 
-**Demo state after this milestone:** live URL generates a full port call package (FAL 1 + FAL 5 + AIS Evidence); each PDF displays its BLAKE3 hash; verify link confirms authenticity in < 1 second.
+**Demo state after this milestone:** native app generates a full port call package (FAL 1 + FAL 5 + AIS Evidence); each PDF displays its BLAKE3 hash; `documaris verify <pdf>` confirms authenticity in < 1 second.
 
-**Deliverables:** Port call package (FAL 1 + FAL 5 + AIS Voyage Evidence) sharing one integrity hash; `documaris verify <pdf>` CLI; maridb audit log entry visible
+**Deliverables:** Port call package (FAL 1 + FAL 5 + AIS Voyage Evidence) sharing one integrity hash; `documaris verify <pdf>` CLI; AuditRecord entry visible in append-only R2 audit bucket
 
 - FAL Form 5 field map (variable crew size)
 - Multi-document output: `documaris generate port-call-package --vessel <id>`
-- Trust Layer: `edgesentry-audit` path dep; BLAKE3 hash on PDF output; hash embedded in XMP metadata; `AuditRecord` written to maridb audit log
+- Trust Layer: `edgesentry-audit` path dep; BLAKE3 hash on PDF output; hash embedded in XMP metadata; `DocumentAuditPayload` serialised → `edgesentry-audit` seal → `AuditRecord` written to local audit log + synced to append-only R2 audit bucket
 - AIS Voyage Evidence: DuckDB query on maridb R2 AIS events → AI fill natural-language voyage summary → signed companion document appended to the package
 
 ---
 
 ### Milestone 3 — Singapore package + Regulatory Alert + PoC measurement (Week 4)
 
-**Demo state after this milestone:** live URL adds "Singapore port entry package" button; a pre-loaded non-compliant vessel triggers a visible HIGH alert that blocks the generate button. PoC KPI report published.
+**Demo state after this milestone:** native app adds "Singapore port entry package" button; a pre-loaded non-compliant vessel triggers a visible HIGH alert that blocks the generate button. PoC KPI report published.
 
 **Deliverables:** `singapore_port_entry_field_map.json` + Regulatory Alert demo on a deliberately non-compliant vessel + PoC KPI report + subscription pricing model draft
 
@@ -80,7 +80,7 @@
 
 ### Milestone 4 — Singapore polish + demo prep (Week 5)
 
-**Demo state after this milestone:** live URL is demo-ready — realistic vessel data, offline mode confirmed, all four differentiators exercisable in a single unscripted walkthrough.
+**Demo state after this milestone:** native app is demo-ready — realistic vessel data, offline mode confirmed, all four differentiators exercisable in a single unscripted walkthrough.
 
 **Deliverables:** End-to-end Singapore package demo on a real or realistic vessel record; all four differentiators exercisable in one flow
 
@@ -94,11 +94,11 @@
 
 ### Milestone 5 — PIER71 submission polish (Weeks 6–7)
 
-**Demo state:** already live since M1; this milestone polishes presentation, records the screen capture, and finalises the application text. No last-minute scramble.
+**Demo state:** native app already running since M1; this milestone polishes presentation, records the screen capture, and finalises the application text. No last-minute scramble.
 
-**Deliverables:** 2-minute screen recording of the live demo + PIER71 application draft ready for submission (deadline: 15 June 2026)
+**Deliverables:** 2-minute screen recording of the native app demo + PIER71 application draft ready for submission (deadline: 15 June 2026)
 
-The live URL already demonstrates all four differentiators. M5 work is polish and narrative, not new features:
+The native app already demonstrates all four differentiators from M1. M5 work is polish and narrative, not new features:
 
 1. **Data → Documents** — maridb R2 data + local crew JSON → one click → FAL 1 + FAL 5 + Singapore package + AIS Evidence; PDF saved locally
 2. **Verifiable Audit Trail** — hash shown post-generation; `verify` endpoint confirms document against AIS voyage record in < 1 second


### PR DESCRIPTION
## Summary

- **Roadmap rewritten around TC1–TC4 demo gates** — PIER71 demo is four test cases in sequence: TC1 (one-click generation) → TC3 (confidence gate / human review) → TC2 (regulatory alert) → TC4 (audit trace). AIS Voyage Evidence, remote audit sync, and offline mode deferred to Phase 2. PoC reduced from 20 to 5 cases.

- **edgesentry-audit domain boundary enforced** — `edgesentry-audit` is a domain-agnostic library: `seal(bytes, prev_hash, key) → AuditRecord`. All maritime fields (vessel_id, voyage_id, ai_field_values, etc.) moved into `DocumentAuditPayload` owned by documaris. No maritime semantics in the library.

- **Remote audit store clarified** — `maridb audit log` removed throughout. MVP: append-only Cloudflare R2 bucket (tamper-evidence from hash chain, not storage guarantees). Future: **immugate** — a commercial service to be built by this team. Switching requires only changing the store-and-forward endpoint.

- **All ASCII diagrams replaced with Mermaid** — system overview, Trust Layer seal flow, Regulatory Alert flow, Layer 6 render flow.

- **Audit log expanded for root cause analysis** — `DocumentAuditPayload` stores AI-generated field values (Class C, no PII) enabling agents to trace errors without contacting documaris.

## Demo flow (TC1 → TC3 → TC2 → TC4, 2 minutes)

1. **(TC1 — 30 sec)** Load vessel → one click → FAL 1 + FAL 5 + Singapore package + BLAKE3 hash
2. **(TC3 — 30 sec)** Amber-flagged low-confidence field → reviewer corrects → export proceeds
3. **(TC2 — 30 sec)** Expired BWM certificate → HIGH alert fires → export blocked
4. **(TC4 — 30 sec)** `documaris verify <pdf>` → full audit trace: AI value, confidence, reviewer action, timestamp

## Test plan

- [ ] Roadmap: TC1–TC4 table and demo flow narrative are consistent with architecture
- [ ] Architecture: no remaining "maridb audit log" references
- [ ] Architecture: edgesentry-audit interface shows `seal(bytes)` only — no maritime fields
- [ ] Architecture: Mermaid diagrams render correctly
- [ ] Roadmap: M2 gate = TC1 + TC3 + TC4; M3 gate = TC2
- [ ] Roadmap: deferred items (AIS Evidence, offline, remote sync) explicitly listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)