### PR TITLE
fix(documaris): load DuckDB WASM from jsDelivr CDN to satisfy CF Pages 25 MiB limit

### DIFF
--- a/app/src/lib/clarusData.ts
+++ b/app/src/lib/clarusData.ts
@@ -65,21 +65,18 @@ let db: duckdb.AsyncDuckDB | null = null;
 
 async function getDb(): Promise<duckdb.AsyncDuckDB> {
   if (db) return db;
-  const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
-    mvp: {
-      mainModule: new URL("@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm", import.meta.url).href,
-      mainWorker: new URL("@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js", import.meta.url).href,
-    },
-    eh: {
-      mainModule: new URL("@duckdb/duckdb-wasm/dist/duckdb-eh.wasm", import.meta.url).href,
-      mainWorker: new URL("@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js", import.meta.url).href,
-    },
-  };
-  const bundle = await duckdb.selectBundle(MANUAL_BUNDLES);
-  const worker = new Worker(bundle.mainWorker!);
+  // Use jsDelivr CDN bundles so the large WASM files (~35-41 MiB each) are
+  // not included in the Cloudflare Pages deploy (25 MiB per-file limit).
+  const bundle = await duckdb.selectBundle(duckdb.getJsDelivrBundles());
+  // Worker must be loaded via blob URL to satisfy same-origin worker policy.
+  const workerUrl = URL.createObjectURL(
+    new Blob([`importScripts("${bundle.mainWorker!}");`], { type: "text/javascript" }),
+  );
+  const worker = new Worker(workerUrl);
   const logger = new duckdb.ConsoleLogger(duckdb.LogLevel.ERROR);
   db = new duckdb.AsyncDuckDB(logger, worker);
   await db.instantiate(bundle.mainModule);
+  URL.revokeObjectURL(workerUrl);
   return db;
 }
 

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -14,9 +14,6 @@ export default defineConfig({
   build: {
     target: "es2020",
   },
-  optimizeDeps: {
-    exclude: ["@duckdb/duckdb-wasm"],
-  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
## Problem

CI deploy failed with:
```
Error: Pages only supports files up to 25 MiB in size
  assets/duckdb-eh-D-nnNw7L.wasm is 34.1 MiB in size
```

DuckDB-WASM ships two WASM bundles (eh: 34 MiB, mvp: 41 MiB). The previous approach used `new URL("@duckdb/duckdb-wasm/dist/duckdb-eh.wasm", import.meta.url)` which caused Vite to copy both into `dist/assets/`, blowing past the Cloudflare Pages 25 MiB per-file limit.

## Fix

Switch `getDb()` to use `duckdb.getJsDelivrBundles()` — pre-configured CDN URLs for the WASM and worker files. The WASM is fetched from jsDelivr at runtime; nothing oversized is included in the Pages deploy.

The worker is wrapped in a blob URL (`importScripts(...)`) to satisfy the same-origin worker policy when loading from a cross-origin CDN.

Also removes the now-unnecessary `optimizeDeps: { exclude: ["@duckdb/duckdb-wasm"] }` from `vite.config.ts`.

## Result

Build output before: ~77 MiB (two DuckDB WASM files + edgesentry WASM)  
Build output after: ~0.8 MiB (edgesentry WASM only)

## Test plan

- [x] `npm run build` — no DuckDB WASM in `dist/assets/`, build completes cleanly
- [x] `npm test` — 73 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)