### PR TITLE
fix(documaris): query Parquet directly for ?mmsi= deep-link

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -6,6 +6,7 @@ import type { PipelineResult } from "./lib/pipeline.js";
 
 vi.mock("./lib/clarusData.js", () => ({
   loadClarusScenarios: vi.fn(),
+  loadClarusScenarioByMmsi: vi.fn(),
   CLARUS_URL: "https://clarus-d5d.pages.dev",
 }));
 
@@ -14,7 +15,7 @@ vi.mock("./lib/pipeline.js", () => ({
   runPipeline: vi.fn(),
 }));
 
-import { loadClarusScenarios } from "./lib/clarusData.js";
+import { loadClarusScenarios, loadClarusScenarioByMmsi } from "./lib/clarusData.js";
 import { runPipeline } from "./lib/pipeline.js";
 
 const LIVE_SCENARIOS: Scenario[] = [
@@ -39,9 +40,18 @@ const MOCK_RESULT: PipelineResult = {
   durationMs: 50,
 };
 
+const FORTUNE_STAR: Scenario = {
+  ...SCENARIOS[1],
+  mmsi: 563012345,
+  behavioralScore: 72,
+  aisGaps: 12,
+  clarusUrl: "https://clarus-d5d.pages.dev",
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(loadClarusScenarios).mockResolvedValue(LIVE_SCENARIOS);
+  vi.mocked(loadClarusScenarioByMmsi).mockResolvedValue(null);
   vi.mocked(runPipeline).mockResolvedValue(MOCK_RESULT);
   window.history.replaceState({}, "", "/");
 });
@@ -92,7 +102,21 @@ describe("App — ?mmsi= deep-link", () => {
     expect(screen.queryByRole("heading", { name: "documaris" })).not.toBeInTheDocument();
   });
 
-  it("shows the selector normally when mmsi is not found", async () => {
+  it("queries Parquet directly when mmsi is not in the top-3 selector scenarios", async () => {
+    // MV Fortune Star (563012345) is not in LIVE_SCENARIOS — direct lookup fires
+    vi.mocked(loadClarusScenarioByMmsi).mockResolvedValue(FORTUNE_STAR);
+    window.history.replaceState({}, "", "/?mmsi=563012345");
+    render(<App />);
+    await waitFor(() => {
+      expect(vi.mocked(loadClarusScenarioByMmsi)).toHaveBeenCalledWith("563012345");
+    });
+    await waitFor(() => {
+      expect(vi.mocked(runPipeline)).toHaveBeenCalledWith(FORTUNE_STAR.csv);
+    });
+  });
+
+  it("shows the selector when mmsi is not found in Parquet either", async () => {
+    vi.mocked(loadClarusScenarioByMmsi).mockResolvedValue(null);
     window.history.replaceState({}, "", "/?mmsi=000000000");
     render(<App />);
     await waitFor(() => {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -5,7 +5,7 @@ import { AuditPanel } from "./components/AuditPanel.js";
 import { FieldAnalysis } from "./components/FieldAnalysis.js";
 import { runPipeline, type PipelineResult } from "./lib/pipeline.js";
 import { SCENARIOS, type Scenario } from "./lib/fixtures.js";
-import { loadClarusScenarios } from "./lib/clarusData.js";
+import { loadClarusScenarios, loadClarusScenarioByMmsi } from "./lib/clarusData.js";
 
 type Phase =
   | { tag: "select"; scenarios: Scenario[]; loadingClarus: boolean }
@@ -34,9 +34,15 @@ export default function App() {
       }
     }
 
-    loadClarusScenarios()
-      .then((live) => {
-        const target = paramMmsi ? live.find((s) => String(s.mmsi) === paramMmsi) : null;
+    // Load the 3 selector scenarios in parallel with the MMSI lookup (if any).
+    // If a specific MMSI is requested, query the Parquet for that vessel directly
+    // rather than relying on it being in the pre-selected top-3.
+    const scenariosPromise = loadClarusScenarios();
+    const mmsiPromise = paramMmsi ? loadClarusScenarioByMmsi(paramMmsi) : Promise.resolve(null);
+
+    Promise.all([scenariosPromise, mmsiPromise])
+      .then(([live, byMmsi]) => {
+        const target = byMmsi ?? (paramMmsi ? live.find((s) => String(s.mmsi) === paramMmsi) : null);
         if (target) {
           autoSelect(target, live);
         } else {

--- a/app/src/lib/clarusData.ts
+++ b/app/src/lib/clarusData.ts
@@ -80,50 +80,78 @@ async function getDb(): Promise<duckdb.AsyncDuckDB> {
   return db;
 }
 
+// ── shared: register parquet and fetch a row ──────────────────────────────────
+
+async function getConn(): Promise<{ conn: duckdb.AsyncDuckDBConnection; close: () => Promise<void> }> {
+  const db = await getDb();
+  await db.registerFileURL("vessels.parquet", CLARUS_PARQUET_URL, duckdb.DuckDBDataProtocol.HTTP, false);
+  const conn = await db.connect();
+  return { conn, close: () => conn.close() };
+}
+
+function rowToVesselRow(r: Record<string, unknown>): VesselRow {
+  return {
+    mmsi:                Number(r.mmsi),
+    vessel_name:         String(r.vessel_name),
+    flag_state:          String(r.flag_state),
+    vessel_type:         String(r.vessel_type),
+    behavioral_score:    Number(r.behavioral_score),
+    ais_gap_count_30d:   Number(r.ais_gap_count_30d),
+    ais_gap_max_hours:   Number(r.ais_gap_max_hours),
+    sts_candidate_count: Number(r.sts_candidate_count),
+  };
+}
+
+// ── load a single vessel by MMSI for deep-link ────────────────────────────────
+
+export async function loadClarusScenarioByMmsi(mmsi: string): Promise<Scenario | null> {
+  const { conn, close } = await getConn();
+  try {
+    const result = await conn.query(`
+      SELECT mmsi, vessel_name, flag_state, vessel_type,
+             behavioral_score, ais_gap_count_30d, ais_gap_max_hours, sts_candidate_count
+      FROM parquet_scan('vessels.parquet')
+      WHERE mmsi = '${mmsi}' AND vessel_name IS NOT NULL
+      LIMIT 1
+    `);
+    const rows = result.toArray();
+    if (rows.length === 0) return null;
+    const v = rowToVesselRow(rows[0] as Record<string, unknown>);
+    const desc = v.behavioral_score > 60
+      ? `High-risk vessel — ${v.ais_gap_count_30d} AIS gaps in 30 days. BWM certificate expired.`
+      : v.behavioral_score > 30
+      ? "Medium-risk vessel — vague cargo description, crew count missing."
+      : "Compliant voyage — all fields valid, 0 alerts expected.";
+    const id = v.behavioral_score > 60 ? "TC2" : v.behavioral_score > 30 ? "TC3" : "TC1";
+    return vesselToScenario(id, v, desc);
+  } finally {
+    await close();
+  }
+}
+
 // ── main export ───────────────────────────────────────────────────────────────
 
 export async function loadClarusScenarios(): Promise<Scenario[]> {
-  const db = await getDb();
-  const conn = await db.connect();
+  const { conn, close } = await getConn();
 
   try {
-    // Register the remote Parquet file
-    await db.registerFileURL(
-      "vessels.parquet",
-      CLARUS_PARQUET_URL,
-      duckdb.DuckDBDataProtocol.HTTP,
-      false,
-    );
-
     const result = await conn.query(`
       WITH ranked AS (
         SELECT *,
           ROW_NUMBER() OVER (ORDER BY behavioral_score DESC)  AS rn_high,
           ROW_NUMBER() OVER (ORDER BY behavioral_score ASC)   AS rn_low,
-          ROW_NUMBER() OVER (
-            ORDER BY ABS(behavioral_score - 40) ASC
-          ) AS rn_mid
+          ROW_NUMBER() OVER (ORDER BY ABS(behavioral_score - 40) ASC) AS rn_mid
         FROM parquet_scan('vessels.parquet')
         WHERE vessel_name IS NOT NULL
       )
       SELECT mmsi, vessel_name, flag_state, vessel_type,
-             behavioral_score, ais_gap_count_30d, ais_gap_max_hours,
-             sts_candidate_count
+             behavioral_score, ais_gap_count_30d, ais_gap_max_hours, sts_candidate_count
       FROM ranked
       WHERE rn_high = 1 OR rn_low = 1 OR rn_mid = 1
       LIMIT 3
     `);
 
-    const rows: VesselRow[] = result.toArray().map((r) => ({
-      mmsi:               Number(r.mmsi),
-      vessel_name:        String(r.vessel_name),
-      flag_state:         String(r.flag_state),
-      vessel_type:        String(r.vessel_type),
-      behavioral_score:   Number(r.behavioral_score),
-      ais_gap_count_30d:  Number(r.ais_gap_count_30d),
-      ais_gap_max_hours:  Number(r.ais_gap_max_hours),
-      sts_candidate_count: Number(r.sts_candidate_count),
-    }));
+    const rows: VesselRow[] = result.toArray().map((r) => rowToVesselRow(r as Record<string, unknown>));
 
     // Sort: highest risk first, then medium, then lowest
     rows.sort((a, b) => b.behavioral_score - a.behavioral_score);
@@ -135,7 +163,7 @@ export async function loadClarusScenarios(): Promise<Scenario[]> {
       vesselToScenario("TC3", mid,  "Medium-risk vessel — vague cargo description, crew count missing."),
     ];
   } finally {
-    await conn.close();
+    await close();
   }
 }
 


### PR DESCRIPTION
## Problem

`https://documaris.pages.dev/?mmsi=563012345` (MV Fortune Star — the clarus demo spotlight) showed the selector instead of the vessel result.

Root cause: the deep-link only looked for the MMSI in the 3 pre-selected vessels (highest/medium/lowest behavioral score). MV Fortune Star is not guaranteed to be any of those 3, so the lookup returned `null` and the selector showed.

## Fix

Adds `loadClarusScenarioByMmsi(mmsi)` which queries the Parquet directly for the requested MMSI, independent of the top-3 selector. Both queries run in parallel (`Promise.all`); the direct lookup takes priority over a pre-selected match.

```
?mmsi=563012345
  ├── loadClarusScenarios()       → top-3 selector vessels (background)
  └── loadClarusScenarioByMmsi() → queries Parquet for mmsi=563012345 directly
```

If neither finds the MMSI (vessel not in dataset), the selector shows normally.

## Test plan

- [x] `npm test` — 81/81 pass (2 new tests: direct lookup fires, selector shown when not found)
- [x] `npm run build` — clean
- [ ] `https://documaris.pages.dev/?mmsi=563012345` — shows FAL Form 1 for MV Fortune Star

🤖 Generated with [Claude Code](https://claude.com/claude-code)