### PR TITLE
chore: gitignore app/tsconfig.tsbuildinfo and app/dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ _outputs/
 .pytest_cache
 __pycache__
 .DS_Store
+app/tsconfig.tsbuildinfo
+app/dist/


### PR DESCRIPTION
`app/tsconfig.tsbuildinfo` is regenerated by `tsc -b` on every build — it was causing a dirty working tree on every pull/build cycle. `app/dist/` is also build output that shouldn't be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)