### PR TITLE
feat(documaris): PDF export via window.print()

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import App from "./App.js";
 import { SCENARIOS, type Scenario } from "./lib/fixtures.js";
@@ -135,5 +135,43 @@ describe("App — result header clarus link", () => {
     });
     const link = screen.getByText("View risk profile in clarus →").closest("a")!;
     expect(link.getAttribute("href")).toBe("https://clarus-d5d.pages.dev?mmsi=477123456");
+  });
+});
+
+describe("App — PDF export", () => {
+  let printSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    printSpy = vi.spyOn(window, "print").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    printSpy.mockRestore();
+  });
+
+  it("renders the Download PDF button on the result panel", async () => {
+    window.history.replaceState({}, "", "/?mmsi=477123456");
+    render(<App />);
+    await waitFor(() => {
+      expect(screen.getByText(/Download PDF/)).toBeInTheDocument();
+    });
+  });
+
+  it("calls window.print() when Download PDF is clicked", async () => {
+    window.history.replaceState({}, "", "/?mmsi=477123456");
+    render(<App />);
+    await waitFor(() => {
+      expect(screen.getByText(/Download PDF/)).toBeInTheDocument();
+    });
+    screen.getByText(/Download PDF/).click();
+    expect(printSpy).toHaveBeenCalledOnce();
+  });
+
+  it("does not show Download PDF button on the selector screen", async () => {
+    render(<App />);
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "documaris" })).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Download PDF/)).not.toBeInTheDocument();
   });
 });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -127,6 +127,9 @@ export default function App() {
             View risk profile in clarus →
           </a>
         )}
+        <button className="pdf-btn" onClick={() => window.print()}>
+          ⬇ Download PDF
+        </button>
         {result.filled.review_required && (
           <div className="review-banner">
             ⚠ review_required — one or more fields need human confirmation before submission
@@ -157,7 +160,7 @@ export default function App() {
             <FieldAnalysis filled={result.filled} />
           </section>
 
-          <section className="section" style={{ marginTop: 24 }}>
+          <section className="section fal-section" style={{ marginTop: 24 }}>
             <h2>FAL Form 1 — General Declaration</h2>
             <div
               className="fal-form"

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -221,6 +221,50 @@ body {
 .fal-form td, .fal-form th { border: 1px solid #ccc; padding: 6px 10px; }
 .fal-form th { background: #f0f0f0; font-weight: 600; }
 
+/* ── PDF download button ── */
+.pdf-btn {
+  margin-left: auto;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  padding: 6px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  white-space: nowrap;
+}
+.pdf-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+/* ── Print / PDF ── */
+@media print {
+  /* Hide everything except the FAL form */
+  .result-header,
+  .result-left,
+  .section:not(.fal-section) {
+    display: none !important;
+  }
+
+  /* FAL form takes full page width */
+  .result-body {
+    display: block !important;
+  }
+  .result-right {
+    padding: 0;
+  }
+  .fal-section {
+    margin-top: 0 !important;
+  }
+  .fal-form {
+    border: none;
+    padding: 0;
+    font-size: 12px;
+  }
+  body {
+    background: white;
+    color: black;
+  }
+}
+
 /* ── Error ── */
 .error-screen { padding: 48px 24px; max-width: 600px; margin: 0 auto; }
 .error-screen h2 { margin-bottom: 16px; color: var(--high); }


### PR DESCRIPTION
## Summary

Adds a **"⬇ Download PDF"** button to the result panel header. Uses `window.print()` + `@media print` CSS — zero dependencies, works offline, no infra required.

### What prints

- FAL Form 1 table (full page width, white background)

### What is hidden in print

- Result header (back button, vessel info, clarus link)
- Left panel (compliance alerts, audit record)
- AI field analysis section

### How it works

```
User clicks "⬇ Download PDF"
  → window.print()
  → Browser print dialog opens
  → User selects "Save as PDF" (Chrome/Safari/Firefox)
  → PDF contains only the FAL Form 1 table
```

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 81/81 pass
- [ ] Run pipeline on any scenario → click "⬇ Download PDF" → print dialog shows FAL Form 1 only
- [ ] Verify header, alerts, audit panel, AI analysis are not in the PDF output
- [ ] Test on Chrome, Safari, Firefox

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)