### PR TITLE
fix: enable Mermaid in MkDocs; add diagram rule to CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Maritime document generation and compliance automation platform. documaris produ
 - TypeScript strict mode (`tsconfig.json`)
 - No unused locals or parameters
 - Python: `uv run` for all commands; pytest for schema/contract tests
+- Docs: use Mermaid for diagrams — see [CONTRIBUTING.md](CONTRIBUTING.md#diagrams)
 
 ## Commit convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,19 @@ All files under `docs/` use `kebab-case.md` with role prefixes:
 | `ui-` | UI/UX specifications and personas |
 | `roadmap/` | Roadmap documents (subdirectory) |
 
+### Diagrams
+
+Use Mermaid for all diagrams in `docs/`. Raw ASCII art in docs is not allowed — it does not render in the MkDocs site.
+
+```
+```mermaid
+flowchart TD
+    A --> B
+```
+```
+
+`mkdocs.yml` already has `pymdownx.superfences` with `custom_fences` for Mermaid — no additional config needed.
+
 ### Skill-first policy
 
 Before adding a procedure to `docs/`, create a Skill instead. Only reference material (facts, schemas, design decisions) goes in `docs/`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,11 @@ plugins:
   - search
 
 markdown_extensions:
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.inlinehilite


### PR DESCRIPTION
## Summary

- `mkdocs.yml`: add `pymdownx.superfences` `custom_fences` for Mermaid — fixes diagram rendering in the docs site
- `CONTRIBUTING.md`: add `### Diagrams` rule — use Mermaid for all diagrams, no ASCII art
- `AGENTS.md`: reference `CONTRIBUTING.md#diagrams` in coding conventions

## Test plan

- [ ] `mkdocs build --strict` passes (docs-check CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)