### PR TITLE
docs: ZKP Portfolio Attestation — README + architecture reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ site/
 uv.lock
 scripts/node_modules/
 .wrangler/
+app/tsconfig.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Built for the [PIER71 Smart Port Challenge 2026](https://pier71.sg) — Innovati
 3. **Checks for regulatory conflicts** against a per-port knowledge base before generating the PDF — expired certificates, missed pre-notification windows, and DG restrictions surface as HIGH/MEDIUM/LOW alerts
 4. **Renders PDFs** server-side for non-PII forms; entirely in-browser via WASM for crew data (FAL Form 5) — crew PII never transits the server
 5. **Signs every document** with a BLAKE3 hash + Ed25519 signature and appends an AIS Voyage Evidence Summary — the full package is cryptographically verifiable
+6. **Verifies ZKP attestations** from the clarus WORM chain — proves BCA Green Mark compliance without exposing raw sensor data. Navigate directly to BCA mode: `?mode=bca`.
 
 ---
 
@@ -25,6 +26,7 @@ Built for the [PIER71 Smart Port Challenge 2026](https://pier71.sg) — Innovati
 | Open source (MIT) | IMO FAL Form 1 — General Declaration | MVP |
 | Open source (MIT) | IMO FAL Form 5 — Crew List | MVP |
 | Commercial | Singapore port entry package (MPA Port+, ICA, TradeNet, SFA) | MVP |
+| Commercial | BCA Green Mark Section 4 + ZKP Portfolio Attestation | Live |
 | Phase 2 roadmap | Japan port entry package (NACCS — Hakata / Tokyo) | Post-PIER71 |
 
 ---
@@ -83,5 +85,7 @@ See [`edgesentry-commercial/docs/strategy/platform-story.md`](https://github.com
 ## Status
 
 Live demo: **[documaris.edgesentry.io](https://documaris.edgesentry.io/analysis/)**
+
+**PR #56 (ZKP Portfolio Attestation) merged 2026-05-09.**
 
 **PIER71 application deadline: 15 June 2026**

--- a/docs/ref-architecture.md
+++ b/docs/ref-architecture.md
@@ -282,6 +282,35 @@ flowchart TD
 
 ---
 
+## ZKP Portfolio Attestation
+
+documaris can verify BCA Green Mark compliance attestations from the clarus WORM audit chain — without accessing raw sensor data. This is the fourth trust layer alongside BLAKE3 hash, Ed25519 signature, and audit chain integrity.
+
+```
+clarus edge (on-premises)          clarus WORM chain (R2)
+──────────────────────────         ───────────────────────
+Sensor data (private)              chains/{site}/{run}/{seq}.json
+→ GreenMarkProgram.prove()         └── zk_proof.public_values
+→ ZkProof { public_values }             = base64(GreenMarkAttestation)
+  (cert_level, pass/fail only)
+  Raw EUI/COP/LPD: never stored         ↓
+                                  documaris AttestationView
+                                  decodes public_values
+                                  displays cert level + PASS/FAIL
+                                  raw sensor data: never fetched
+```
+
+**`fetchSiteAttestation(siteId)`** discovery order:
+1. `zkp-latest/{site}.json` — edge-written pointer; single GET (strongly consistent)
+2. `/api/audit-summary?site=X` — clarus Pages Function (run list)
+3. `/api/audit-index?site=X` — key listing fallback
+
+**URL routing:** `?mode=bca` navigates directly to BCA Green Mark + ZKP view. URL updates on tab switch so BCA-focused teams can bookmark directly.
+
+**API:** `GET /api/bca-portfolio/:owner` → `PortfolioAttestation` JSON — for BCA integration and downstream audit systems.
+
+---
+
 ## OCR / Reverse Ingestion (Phase 2 — post-PIER71 roadmap)
 
 ```


### PR DESCRIPTION
Docs-only follow-up to PR #56 (merged).

## Summary
- `README.md` — step 6 (ZKP attestation), BCA Green Mark row, `?mode=bca` note
- `docs/ref-architecture.md` — new "ZKP Portfolio Attestation" section: clarus → WORM chain → AttestationView data flow, `fetchSiteAttestation` discovery order, `/api/bca-portfolio/:owner` API
- `.gitignore` — ignore `app/tsconfig.tsbuildinfo`

Rebased cleanly onto main (1 commit, no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)