### PR TITLE
feat(zkp): BLAKE3 proof verification + R2 site registry + 4-quadrant E2E view

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
+        "@noble/hashes": "^2.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1189,6 +1190,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
+    "@noble/hashes": "^2.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/app/src/components/AttestationView.test.tsx
+++ b/app/src/components/AttestationView.test.tsx
@@ -1,14 +1,26 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+// @ts-ignore
+import { blake3 } from "@noble/hashes/blake3.js";
 import { AttestationView } from "./AttestationView.js";
 import type { OperatorSummary } from "../lib/bcaData.js";
 import type { GreenMarkAttestation } from "../lib/attestation.js";
+
+function b64Encode(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+function validProofBytes(att: GreenMarkAttestation): string {
+  const json  = JSON.stringify(att);
+  const bytes = new TextEncoder().encode(json);
+  return b64Encode(blake3(bytes));
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeAttestation(overrides: Partial<GreenMarkAttestation> = {}): GreenMarkAttestation {
   return {
-    site_id: "MCH-OUTLET-BCA",
+    site_id: "MCH-OUTLET-042",
     eui_kwh_m2: 105.0,
     cert_level: "gold",
     all_criteria_pass: true,
@@ -28,18 +40,38 @@ function makeRecord(seq: number, att?: GreenMarkAttestation) {
     record_hash_hex: "a".repeat(64),
     ...(att ? {
       zk_proof: {
-        framework: "mock",
-        program_id: "bca-green-mark-2021-v1-mock",
-        proof_bytes: "dGVzdA==",
+        framework:    "mock",
+        program_id:   "bca-green-mark-2021-v1-mock",
+        proof_bytes:  validProofBytes(att),   // correct blake3 → proof_valid: true
         public_values: btoa(JSON.stringify(att)),
       }
     } : {}),
   };
 }
 
-function mockClarusFetch(att?: GreenMarkAttestation) {
+function makeRegistry(operatorId = "MCH-OPERATOR-001", siteId = "MCH-OUTLET-042") {
+  return {
+    version: "1",
+    sites: [{ site_id: siteId, name: siteId, operator_id: operatorId, profile: "sg-bca-greenmark" }],
+  };
+}
+
+/**
+ * Mock fetch for all URLs the component touches:
+ *   registry/bca-sites.json  → returns a one-site registry
+ *   data/raw/zkp-latest/...  → 404 (falls through to audit-summary)
+ *   api/audit-summary        → returns one run at seq 0
+ *   data/audit/...           → returns the given audit record
+ */
+function mockFetch(att?: GreenMarkAttestation) {
   vi.stubGlobal("fetch", vi.fn(async (url: string) => {
-    if (url.includes("/api/audit-summary")) {
+    if (url.includes("registry/bca-sites.json")) {
+      return { ok: true, json: async () => makeRegistry() };
+    }
+    if (url.includes("zkp-latest")) {
+      return { ok: false, status: 404 };
+    }
+    if (url.includes("audit-summary")) {
       return { ok: true, json: async () => ({ runs: [{ run_id: "1000", record_count: 1, last_seq: 0 }] }) };
     }
     const record = att ? makeRecord(0, att) : makeRecord(0);
@@ -49,8 +81,8 @@ function mockClarusFetch(att?: GreenMarkAttestation) {
 
 const OPERATORS: OperatorSummary[] = [
   {
-    operator_id: "MCH-OUTLET-BCA",
-    operator_name: "MCH-OUTLET-BCA",
+    operator_id: "MCH-OPERATOR-001",
+    operator_name: "MCH-OPERATOR-001",
     site_count: 1,
     compliant_count: 1,
     needs_action_count: 0,
@@ -65,83 +97,130 @@ describe("AttestationView", () => {
   beforeEach(() => vi.restoreAllMocks());
   afterEach(() => vi.restoreAllMocks());
 
-  it("renders the page heading and WORM badge", () => {
-    mockClarusFetch();
+  it("renders the page heading and tamper-proof badge", () => {
+    mockFetch();
     render(<AttestationView operators={[]} />);
     expect(screen.getByText(/BCA Green Mark/)).toBeInTheDocument();
-    expect(screen.getByText(/WORM-sealed/)).toBeInTheDocument();
+    expect(screen.getByText(/Tamper-proof records/)).toBeInTheDocument();
   });
 
-  it("shows loading state while fetching", () => {
-    // Never resolve to keep it loading
-    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
+  it("shows loading state while fetching attestations", async () => {
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      // Registry resolves immediately so the portfolio fetch can start
+      if (url.includes("registry/bca-sites.json")) {
+        return { ok: true, json: async () => makeRegistry() };
+      }
+      // Everything else stays pending → component stays in loading state
+      return new Promise(() => {});
+    }));
     render(<AttestationView operators={OPERATORS} />);
-    expect(screen.getByText(/Fetching ZKP attestations/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/Retrieving certification records/)).toBeInTheDocument();
+    });
   });
 
   it("displays cert level badge when attestation is available", async () => {
-    mockClarusFetch(makeAttestation({ cert_level: "gold", all_criteria_pass: true }));
+    mockFetch(makeAttestation({ cert_level: "gold" }));
     render(<AttestationView operators={OPERATORS} />);
-
     await waitFor(() => {
       expect(screen.getByText("Gold")).toBeInTheDocument();
     });
   });
 
-  it("shows PASS for all_criteria_pass: true", async () => {
-    mockClarusFetch(makeAttestation({ all_criteria_pass: true }));
+  it("shows Certified status for all_criteria_pass: true", async () => {
+    mockFetch(makeAttestation({ all_criteria_pass: true }));
     render(<AttestationView operators={OPERATORS} />);
-
     await waitFor(() => {
-      expect(screen.getByText(/✓ PASS/)).toBeInTheDocument();
+      expect(screen.getByText(/✓ Certified/)).toBeInTheDocument();
     });
   });
 
-  it("shows FAIL for all_criteria_pass: false", async () => {
-    mockClarusFetch(makeAttestation({ all_criteria_pass: false, cert_level: "not_certified" }));
+  it("shows Below standard status for all_criteria_pass: false", async () => {
+    mockFetch(makeAttestation({ all_criteria_pass: false, cert_level: "not_certified" }));
     render(<AttestationView operators={OPERATORS} />);
-
     await waitFor(() => {
-      expect(screen.getByText(/✗ FAIL/)).toBeInTheDocument();
+      expect(screen.getByText(/Below standard/)).toBeInTheDocument();
     });
   });
 
-  it("shows portfolio summary banner when attestation loads", async () => {
-    mockClarusFetch(makeAttestation({ all_criteria_pass: true }));
+  it("shows all sites pass banner when every site is compliant", async () => {
+    mockFetch(makeAttestation({ all_criteria_pass: true }));
     render(<AttestationView operators={OPERATORS} />);
-
     await waitFor(() => {
-      expect(screen.getByText(/Portfolio compliant/)).toBeInTheDocument();
+      expect(screen.getByText(/meet the BCA Green Mark standard/)).toBeInTheDocument();
     });
   });
 
-  it("shows partial pass banner when some sites fail", async () => {
-    mockClarusFetch(makeAttestation({ all_criteria_pass: false, cert_level: "not_certified" }));
+  it("shows partial pass count when some sites fail", async () => {
+    mockFetch(makeAttestation({ all_criteria_pass: false, cert_level: "not_certified" }));
     render(<AttestationView operators={OPERATORS} />);
-
     await waitFor(() => {
-      expect(screen.getByText(/0\/1 sites passing/)).toBeInTheDocument();
+      expect(screen.getByText(/0 of 1 sites meet/)).toBeInTheDocument();
     });
   });
 
-  it("shows operator_id in summary banner", async () => {
-    mockClarusFetch(makeAttestation());
+  it("shows Data integrity issue status for tampered proof", async () => {
+    // proof_bytes that doesn't match blake3(public_values) → proof_valid: false
+    const att = makeAttestation({ all_criteria_pass: true, cert_level: "gold" });
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      if (url.includes("registry/bca-sites.json"))
+        return { ok: true, json: async () => makeRegistry() };
+      if (url.includes("zkp-latest"))
+        return { ok: false, status: 404 };
+      if (url.includes("audit-summary"))
+        return { ok: true, json: async () => ({ runs: [{ run_id: "1000", record_count: 1, last_seq: 0 }] }) };
+      return { ok: true, json: async () => ({
+        ...makeRecord(0),
+        zk_proof: {
+          framework: "mock",
+          program_id: "bca-green-mark-2021-v1-mock",
+          proof_bytes: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", // wrong hash
+          public_values: btoa(JSON.stringify(att)),
+        },
+      })};
+    }));
     render(<AttestationView operators={OPERATORS} />);
-
     await waitFor(() => {
-      expect(screen.getByText(/Operator: MCH-OUTLET-BCA/)).toBeInTheDocument();
+      expect(screen.getByText(/Data integrity issue/)).toBeInTheDocument();
     });
   });
 
-  it("renders operator selector when operators list is provided", () => {
-    mockClarusFetch();
+  it("shows tamper alert banner when proof is invalid", async () => {
+    const att = makeAttestation({ all_criteria_pass: true });
+    vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+      if (url.includes("registry/bca-sites.json"))
+        return { ok: true, json: async () => makeRegistry() };
+      if (url.includes("zkp-latest"))
+        return { ok: false, status: 404 };
+      if (url.includes("audit-summary"))
+        return { ok: true, json: async () => ({ runs: [{ run_id: "1000", record_count: 1, last_seq: 0 }] }) };
+      return { ok: true, json: async () => ({
+        ...makeRecord(0),
+        zk_proof: {
+          framework: "mock",
+          program_id: "bca-green-mark-2021-v1-mock",
+          proof_bytes: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          public_values: btoa(JSON.stringify(att)),
+        },
+      })};
+    }));
     render(<AttestationView operators={OPERATORS} />);
-    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/could not be verified/)).toBeInTheDocument();
+    });
   });
 
-  it("shows API link for the selected operator", () => {
-    mockClarusFetch();
+  it("renders operator selector driven by registry", async () => {
+    mockFetch();
     render(<AttestationView operators={OPERATORS} />);
-    expect(screen.getByText(/\/api\/bca-portfolio\//)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
+    });
+  });
+
+  it("shows API export link", () => {
+    mockFetch();
+    render(<AttestationView operators={OPERATORS} />);
+    expect(screen.getByText(/Export as JSON/)).toBeInTheDocument();
   });
 });

--- a/app/src/components/AttestationView.test.tsx
+++ b/app/src/components/AttestationView.test.tsx
@@ -131,7 +131,8 @@ describe("AttestationView", () => {
     mockFetch(makeAttestation({ all_criteria_pass: true }));
     render(<AttestationView operators={OPERATORS} />);
     await waitFor(() => {
-      expect(screen.getByText(/✓ Certified/)).toBeInTheDocument();
+      // "✓ Certified" appears in both the filter pill and the status badge
+      expect(screen.getAllByText(/✓ Certified/).length).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -139,7 +140,7 @@ describe("AttestationView", () => {
     mockFetch(makeAttestation({ all_criteria_pass: false, cert_level: "not_certified" }));
     render(<AttestationView operators={OPERATORS} />);
     await waitFor(() => {
-      expect(screen.getByText(/Below standard/)).toBeInTheDocument();
+      expect(screen.getAllByText(/Below standard/).length).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -159,7 +160,7 @@ describe("AttestationView", () => {
     });
   });
 
-  it("shows Data integrity issue status for tampered proof", async () => {
+  it("shows Data integrity issue status for tampered proof (filter pill + row badge)", async () => {
     // proof_bytes that doesn't match blake3(public_values) → proof_valid: false
     const att = makeAttestation({ all_criteria_pass: true, cert_level: "gold" });
     vi.stubGlobal("fetch", vi.fn(async (url: string) => {
@@ -181,7 +182,7 @@ describe("AttestationView", () => {
     }));
     render(<AttestationView operators={OPERATORS} />);
     await waitFor(() => {
-      expect(screen.getByText(/Data integrity issue/)).toBeInTheDocument();
+      expect(screen.getAllByText(/Data integrity issue/).length).toBeGreaterThanOrEqual(1);
     });
   });
 

--- a/app/src/components/AttestationView.tsx
+++ b/app/src/components/AttestationView.tsx
@@ -12,15 +12,23 @@ import {
 } from "../lib/attestation.js";
 import type { OperatorSummary } from "../lib/bcaData.js";
 
-// ── Sub-components ────────────────────────────────────────────────────────────
+// ── Cert level display ────────────────────────────────────────────────────────
+
+const CERT_DESCRIPTIONS: Record<CertLevel, string> = {
+  platinum:      "BCA Green Mark Platinum — 最高水準のエネルギー効率",
+  gold_plus:     "BCA Green Mark GoldPlus — 優秀なエネルギー効率",
+  gold:          "BCA Green Mark Gold — 良好なエネルギー効率",
+  certified:     "BCA Green Mark Certified — 基準を満たす",
+  not_certified: "非認定 — BCA基準を満たしていません",
+};
 
 function CertBadge({ level }: { level: CertLevel }) {
   return (
     <span style={{
       display: "inline-block",
-      padding: "2px 10px",
+      padding: "3px 12px",
       borderRadius: 10,
-      fontSize: 11,
+      fontSize: 12,
       fontWeight: 700,
       background: certLevelColor(level) + "22",
       color: certLevelColor(level),
@@ -31,11 +39,49 @@ function CertBadge({ level }: { level: CertLevel }) {
   );
 }
 
-function ProofBadge({ proof_valid }: { proof_valid: boolean | null }) {
-  if (proof_valid === true)  return <span style={{ color: "#3fb950", fontSize: 11, fontWeight: 700 }}>✓ valid</span>;
-  if (proof_valid === false) return <span style={{ color: "#f85149", fontSize: 11, fontWeight: 700 }}>✗ TAMPERED</span>;
-  return <span style={{ color: "#8b949e", fontSize: 11 }}>SP1 (pending)</span>;
+// ── Trust status badge ────────────────────────────────────────────────────────
+
+function TrustBadge({ proof_valid, all_criteria_pass }: { proof_valid: boolean | null; all_criteria_pass: boolean | undefined }) {
+  if (proof_valid === false) {
+    return (
+      <span style={{
+        display: "inline-flex", alignItems: "center", gap: 4,
+        color: "#f85149", fontSize: 12, fontWeight: 700,
+        background: "rgba(248,81,73,0.12)", border: "1px solid rgba(248,81,73,0.4)",
+        borderRadius: 10, padding: "3px 10px",
+      }}>
+        ⚠ データ信頼性に問題あり
+      </span>
+    );
+  }
+  if (all_criteria_pass === true) {
+    return (
+      <span style={{
+        display: "inline-flex", alignItems: "center", gap: 4,
+        color: "#3fb950", fontSize: 12, fontWeight: 700,
+        background: "rgba(63,185,80,0.12)", border: "1px solid rgba(63,185,80,0.4)",
+        borderRadius: 10, padding: "3px 10px",
+      }}>
+        ✓ 認証取得済み
+      </span>
+    );
+  }
+  if (all_criteria_pass === false) {
+    return (
+      <span style={{
+        display: "inline-flex", alignItems: "center", gap: 4,
+        color: "#d29922", fontSize: 12, fontWeight: 600,
+        background: "rgba(210,153,34,0.12)", border: "1px solid rgba(210,153,34,0.4)",
+        borderRadius: 10, padding: "3px 10px",
+      }}>
+        — 基準未達
+      </span>
+    );
+  }
+  return <span style={{ color: "#8b949e", fontSize: 12 }}>確認中</span>;
 }
+
+// ── Site row ──────────────────────────────────────────────────────────────────
 
 function SiteRow({ site }: { site: SiteAttestation }) {
   const [expanded, setExpanded] = useState(false);
@@ -52,83 +98,134 @@ function SiteRow({ site }: { site: SiteAttestation }) {
           borderLeft: isTampered ? "3px solid #f85149" : "3px solid transparent",
         }}
       >
-        <td style={{ fontFamily: "monospace", fontSize: 12, padding: "8px 12px" }}>
-          {site.site_id}
-          {isTampered && (
-            <span style={{
-              marginLeft: 8, fontSize: 10, fontWeight: 700,
-              background: "rgba(248,81,73,0.15)", color: "#f85149",
-              border: "1px solid rgba(248,81,73,0.4)", borderRadius: 8, padding: "1px 6px",
-            }}>
-              ⚠ PROOF INVALID
-            </span>
+        {/* Site name */}
+        <td style={{ padding: "12px 16px" }}>
+          <div style={{ fontSize: 13, fontWeight: 600, fontFamily: "monospace" }}>{site.site_id}</div>
+          {att && (
+            <div style={{ fontSize: 11, color: "#8b949e", marginTop: 2 }}>
+              {CERT_DESCRIPTIONS[att.cert_level]}
+            </div>
           )}
         </td>
-        <td style={{ padding: "8px 12px" }}>
+
+        {/* Certification level */}
+        <td style={{ padding: "12px 16px" }}>
           {att ? <CertBadge level={att.cert_level} /> : <span style={{ color: "#8b949e", fontSize: 12 }}>—</span>}
         </td>
-        <td style={{ textAlign: "center", padding: "8px 12px" }}>
-          {att?.all_criteria_pass === true && !isTampered
-            ? <span style={{ color: "#3fb950", fontWeight: 700 }}>✓ PASS</span>
-            : att?.all_criteria_pass === true && isTampered
-            ? <span style={{ color: "#f85149", fontWeight: 700 }}>⚠ UNVERIFIED</span>
-            : att
-            ? <span style={{ color: "#f85149", fontWeight: 700 }}>✗ FAIL</span>
-            : <span style={{ color: "#8b949e" }}>—</span>}
+
+        {/* EUI */}
+        <td style={{ padding: "12px 16px", fontFamily: "monospace", fontSize: 13 }}>
+          {att ? (
+            <span style={{ color: att.all_criteria_pass ? "#e6edf3" : "#f85149" }}>
+              {att.eui_kwh_m2.toFixed(1)}
+            </span>
+          ) : "—"}
         </td>
-        <td style={{ textAlign: "center", fontSize: 12, padding: "8px 12px" }}>
-          {att?.cop_pass === true ? "✓" : att ? "✗" : "—"}
+
+        {/* Compliance status */}
+        <td style={{ padding: "12px 16px" }}>
+          <TrustBadge proof_valid={site.proof_valid} all_criteria_pass={att?.all_criteria_pass} />
         </td>
-        <td style={{ textAlign: "center", fontSize: 12, padding: "8px 12px" }}>
-          {att?.lpd_pass === true ? "✓" : att ? "✗" : "—"}
+
+        {/* Last verified */}
+        <td style={{ padding: "12px 16px", fontSize: 12, color: "#8b949e" }}>
+          {site.attested_at
+            ? site.attested_at.toLocaleDateString("ja-JP", { year: "numeric", month: "2-digit", day: "2-digit" })
+              + " " + site.attested_at.toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" })
+            : "—"}
         </td>
-        <td style={{ fontFamily: "monospace", fontSize: 12, padding: "8px 12px" }}>
-          {site.attested_at ? site.attested_at.toISOString().replace("T", " ").slice(0, 16) + " UTC" : "—"}
-        </td>
-        <td style={{ padding: "8px 12px" }}>
-          <ProofBadge proof_valid={site.proof_valid} />
-        </td>
-        <td style={{ color: "#58a6ff", fontSize: 12, padding: "8px 12px" }}>{expanded ? "▲" : "▼"}</td>
+
+        <td style={{ padding: "12px 16px", color: "#58a6ff", fontSize: 12 }}>{expanded ? "▲" : "▼"}</td>
       </tr>
+
+      {/* Expanded detail */}
       {expanded && (
         <tr>
-          <td colSpan={8} style={{ background: "rgba(88,166,255,0.04)", padding: "12px 16px", borderBottom: "1px solid #30363d" }}>
+          <td colSpan={6} style={{
+            background: isTampered ? "rgba(248,81,73,0.04)" : "rgba(88,166,255,0.03)",
+            padding: "16px 20px",
+            borderBottom: "1px solid #30363d",
+          }}>
             {att ? (
-              <div style={{ display: "grid", gridTemplateColumns: "220px 1fr", gap: "4px 12px", fontSize: 12 }}>
-                <span style={{ color: "#8b949e" }}>EUI</span>
-                <span style={{ fontFamily: "monospace" }}>{att.eui_kwh_m2.toFixed(1)} kWh/m²/year</span>
-                <span style={{ color: "#8b949e" }}>COP pass (≥ 0.65)</span>
-                <span style={{ color: att.cop_pass ? "#3fb950" : "#f85149" }}>{att.cop_pass ? "Yes" : "No"}</span>
-                <span style={{ color: "#8b949e" }}>LPD pass (≤ 15 W/m²)</span>
-                <span style={{ color: att.lpd_pass ? "#3fb950" : "#f85149" }}>{att.lpd_pass ? "Yes" : "No"}</span>
-                <span style={{ color: "#8b949e" }}>ZK proof verification</span>
-                <span>
-                  {site.proof_valid === true  && <span style={{ color: "#3fb950" }}>✓ BLAKE3 hash matches public_values — proof authentic</span>}
-                  {site.proof_valid === false && (
-                    <span style={{ color: "#f85149" }}>
-                      ✗ BLAKE3 hash does NOT match — proof_bytes are tampered or forged.
-                      This record cannot be trusted regardless of the claimed cert_level.
+              <div style={{ display: "flex", gap: 32, flexWrap: "wrap" }}>
+
+                {/* Criteria detail */}
+                <div>
+                  <div style={{ fontSize: 11, color: "#8b949e", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 10 }}>
+                    BCA基準チェック項目
+                  </div>
+                  <div style={{ display: "grid", gridTemplateColumns: "auto auto", gap: "6px 20px", fontSize: 13 }}>
+                    <span style={{ color: "#8b949e" }}>エネルギー使用強度（EUI）</span>
+                    <span style={{ color: att.cop_pass ? "#e6edf3" : "#f85149" }}>
+                      {att.eui_kwh_m2.toFixed(1)} kWh/m²/年
+                      <span style={{ marginLeft: 8, fontSize: 11, color: certLevelColor(att.cert_level) }}>
+                        ({certLevelLabel(att.cert_level)})
+                      </span>
                     </span>
-                  )}
-                  {site.proof_valid === null  && <span style={{ color: "#8b949e" }}>SP1 Groth16 verification pending WASM verifier integration</span>}
-                </span>
-                <span style={{ color: "#8b949e" }}>ZK framework</span>
-                <span style={{ fontFamily: "monospace" }}>mock (SP1 pending)</span>
-                <span style={{ color: "#8b949e" }}>Record hash</span>
-                <span style={{ fontFamily: "monospace", wordBreak: "break-all", color: "#8b949e", fontSize: 11 }}>
-                  {site.record_hash ?? "—"}
-                </span>
-                <span style={{ color: "#8b949e" }}>Raw sensor data</span>
-                <span style={{ color: "#3fb950" }}>Not exposed — stays on edge device ✓</span>
+
+                    <span style={{ color: "#8b949e" }}>冷凍機効率（COP）</span>
+                    <span style={{ color: att.cop_pass ? "#3fb950" : "#f85149" }}>
+                      {att.cop_pass ? "✓ 基準達成（≥ 0.65）" : "✗ 基準未達（< 0.65）"}
+                    </span>
+
+                    <span style={{ color: "#8b949e" }}>照明電力密度（LPD）</span>
+                    <span style={{ color: att.lpd_pass ? "#3fb950" : "#f85149" }}>
+                      {att.lpd_pass ? "✓ 基準達成（≤ 15 W/m²）" : "✗ 基準未達（> 15 W/m²）"}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Data integrity */}
+                <div>
+                  <div style={{ fontSize: 11, color: "#8b949e", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 10 }}>
+                    データの信頼性
+                  </div>
+                  <div style={{ fontSize: 13 }}>
+                    {site.proof_valid === true && (
+                      <div style={{ color: "#3fb950" }}>
+                        ✓ 数値が改ざんされていないことを数学的に検証済み
+                        <div style={{ fontSize: 11, color: "#8b949e", marginTop: 4 }}>
+                          エネルギー計算の元データ（生センサー値）はエッジデバイス内に保持され、
+                          外部に送信されることなく、計算結果のみが認証記録として保存されています。
+                        </div>
+                      </div>
+                    )}
+                    {site.proof_valid === false && (
+                      <div style={{ color: "#f85149" }}>
+                        ⚠ 認証データの整合性が確認できません
+                        <div style={{ fontSize: 11, color: "#f85149", marginTop: 4, opacity: 0.8 }}>
+                          申告されている認証レベルと、実際の計算証明が一致していません。
+                          このデータに基づいて認証を発行することはできません。
+                        </div>
+                      </div>
+                    )}
+                    {site.proof_valid === null && (
+                      <div style={{ color: "#8b949e" }}>
+                        次世代の検証方式（SP1）への移行準備中です。現在は自動確認できません。
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Audit trail */}
+                <div>
+                  <div style={{ fontSize: 11, color: "#8b949e", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 10 }}>
+                    監査記録
+                  </div>
+                  <div style={{ fontSize: 12, color: "#8b949e" }}>
+                    <div>記録ID: <span style={{ fontFamily: "monospace", fontSize: 11 }}>{site.record_hash?.slice(0, 16) ?? "—"}…</span></div>
+                    <div style={{ marginTop: 4 }}>この記録は改ざん防止ストレージに保存されており、後から変更・削除することはできません。</div>
+                  </div>
+                </div>
               </div>
             ) : (
-              <span style={{ color: "#8b949e", fontSize: 12 }}>
+              <div style={{ color: "#8b949e", fontSize: 13 }}>
                 {site.error === "no runs"
-                  ? "No audit records found. Run clarus-edge with PROFILE=sg-bca-greenmark."
+                  ? "このサイトの認証記録がまだありません。"
                   : site.error === "no zk_proof in recent records"
-                  ? "No ZKP-bearing records in the most recent run."
-                  : `Error: ${site.error}`}
-              </span>
+                  ? "直近の記録に認証データが含まれていません。"
+                  : `データ取得エラー: ${site.error}`}
+              </div>
             )}
           </td>
         </tr>
@@ -137,29 +234,63 @@ function SiteRow({ site }: { site: SiteAttestation }) {
   );
 }
 
-// ── 4-quadrant legend ─────────────────────────────────────────────────────────
+// ── Summary banner ────────────────────────────────────────────────────────────
 
-function QuadrantLegend() {
-  const cell = (label: string, color: string, bg: string) => (
-    <div style={{
-      padding: "10px 14px", borderRadius: 6,
-      border: `1px solid ${color}44`,
-      background: bg, fontSize: 11,
-    }}>
-      <div style={{ fontWeight: 700, color, marginBottom: 3 }}>{label}</div>
-    </div>
-  );
+function SummaryBanner({ portfolio }: { portfolio: PortfolioAttestation }) {
+  const tamperCount  = portfolio.sites.filter(s => s.proof_valid === false).length;
+  const passCount    = portfolio.pass_count;
+  const total        = portfolio.total_count;
+  const honestTotal  = total - tamperCount;
+
+  if (tamperCount > 0) {
+    return (
+      <div style={{
+        display: "flex", gap: 16, padding: "16px 20px", borderRadius: 10, marginBottom: 20,
+        border: "1px solid rgba(248,81,73,0.5)", background: "rgba(248,81,73,0.07)",
+      }}>
+        <span style={{ fontSize: 24, lineHeight: 1 }}>🚨</span>
+        <div>
+          <div style={{ fontWeight: 700, fontSize: 15, color: "#f85149" }}>
+            {tamperCount}件のデータ申告に問題が検出されました
+          </div>
+          <div style={{ fontSize: 13, color: "#8b949e", marginTop: 4 }}>
+            信頼性が確認できた {honestTotal} 件のうち、{passCount} 件が BCA Green Mark 基準を満たしています。
+            問題のある申告は認証対象から除外されます。
+          </div>
+        </div>
+        <div style={{ marginLeft: "auto", alignSelf: "center", fontSize: 11, color: "#d29922",
+          background: "rgba(210,153,34,0.1)", border: "1px solid rgba(210,153,34,0.3)",
+          padding: "4px 12px", borderRadius: 12, whiteSpace: "nowrap" }}>
+          🔒 記録は削除・変更不可
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div style={{ marginBottom: 16 }}>
-      <div style={{ fontSize: 11, color: "#8b949e", marginBottom: 6 }}>
-        E2E test matrix — all 4 quadrants of ZKP computation × BCA criteria:
+    <div style={{
+      display: "flex", gap: 16, padding: "16px 20px", borderRadius: 10, marginBottom: 20,
+      border: portfolio.all_pass
+        ? "1px solid rgba(63,185,80,0.4)" : "1px solid rgba(210,153,34,0.4)",
+      background: portfolio.all_pass
+        ? "rgba(63,185,80,0.07)" : "rgba(210,153,34,0.07)",
+    }}>
+      <span style={{ fontSize: 24, lineHeight: 1 }}>{portfolio.all_pass ? "✅" : "⚠️"}</span>
+      <div>
+        <div style={{ fontWeight: 700, fontSize: 15 }}>
+          {portfolio.all_pass
+            ? `全 ${total} 件が BCA Green Mark 基準を達成しています`
+            : `${total} 件中 ${passCount} 件が BCA Green Mark 基準を達成しています`}
+        </div>
+        <div style={{ fontSize: 13, color: "#8b949e", marginTop: 4 }}>
+          すべての認証データの整合性が確認されています ·
+          確認日時: {portfolio.generated_at.toLocaleString("ja-JP")}
+        </div>
       </div>
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, maxWidth: 560 }}>
-        {cell("Q1 ✓ Correct calc + Passes BCA GM",   "#3fb950", "rgba(63,185,80,0.06)")}
-        {cell("Q2 ✓ Correct calc + Fails BCA GM",    "#d29922", "rgba(210,153,34,0.06)")}
-        {cell("Q3 ✗ Tampered ZKP + Claims PASS → fraud detected",  "#f85149", "rgba(248,81,73,0.06)")}
-        {cell("Q4 ✗ Tampered ZKP + Claims FAIL → sabotage detected", "#f85149", "rgba(248,81,73,0.06)")}
+      <div style={{ marginLeft: "auto", alignSelf: "center", fontSize: 11, color: "#d29922",
+        background: "rgba(210,153,34,0.1)", border: "1px solid rgba(210,153,34,0.3)",
+        padding: "4px 12px", borderRadius: 12, whiteSpace: "nowrap" }}>
+        🔒 記録は削除・変更不可
       </div>
     </div>
   );
@@ -178,24 +309,20 @@ export function AttestationView({ operators }: Props) {
   const [portfolio, setPortfolio]         = useState<PortfolioAttestation | null>(null);
   const [loading, setLoading]             = useState(false);
 
-  // Fetch registry from R2 on mount
   useEffect(() => {
     fetchBcaSiteRegistry()
       .then(setRegistry)
       .catch(e => setRegistryError(String(e)));
   }, []);
 
-  // Derive operator → site_id mapping from registry
   const operatorSiteMap = registry ? sitesByOperator(registry) : {};
 
-  // Set default operator from registry once loaded
   useEffect(() => {
-    if (registry && registry.sites.length > 0 && !operatorSiteMap[selectedOperator]) {
-      setSelectedOperator(Object.keys(operatorSiteMap)[0]);
+    if (registry && !operatorSiteMap[selectedOperator]) {
+      setSelectedOperator(Object.keys(operatorSiteMap)[0] ?? selectedOperator);
     }
   }, [registry]);
 
-  // Fetch attestations whenever selected operator changes
   useEffect(() => {
     const siteIds = operatorSiteMap[selectedOperator];
     if (!siteIds?.length) return;
@@ -206,149 +333,91 @@ export function AttestationView({ operators }: Props) {
       .finally(() => setLoading(false));
   }, [selectedOperator, registry]);
 
-  const tamperCount = portfolio?.sites.filter(s => s.proof_valid === false).length ?? 0;
-
   return (
-    <div style={{ padding: "24px", maxWidth: 1100, margin: "0 auto" }}>
+    <div style={{ padding: "24px", maxWidth: 1000, margin: "0 auto" }}>
 
       {/* Header */}
-      <div style={{ marginBottom: 20 }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 8 }}>
-          <h2 style={{ fontSize: 16, fontWeight: 700, margin: 0 }}>
-            BCA Green Mark — ZKP Portfolio Attestation
+      <div style={{ marginBottom: 24 }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 12, marginBottom: 8 }}>
+          <h2 style={{ fontSize: 18, fontWeight: 700, margin: 0 }}>
+            BCA Green Mark 認証ポートフォリオ
           </h2>
           <span style={{
             background: "rgba(63,185,80,0.1)", color: "#3fb950",
             border: "1px solid rgba(63,185,80,0.3)", borderRadius: 12,
             fontSize: 11, fontWeight: 700, padding: "2px 10px",
           }}>
-            WORM-sealed · proof-backed
+            改ざん防止記録
           </span>
-          {registry && (
-            <span style={{
-              background: "rgba(88,166,255,0.1)", color: "#58a6ff",
-              border: "1px solid rgba(88,166,255,0.3)", borderRadius: 12,
-              fontSize: 11, padding: "2px 10px",
-            }}>
-              {registry.sites.length} sites from R2 registry
-            </span>
-          )}
         </div>
-        <p style={{ fontSize: 12, color: "#8b949e", margin: 0 }}>
-          Compliance status derived from ZKP proofs in the clarus WORM audit chain.
-          Raw sensor data (EUI readings, occupancy, area) never transmitted — only the mathematical attestation is read.
-          Proof bytes verified in-browser via BLAKE3.
+        <p style={{ fontSize: 13, color: "#8b949e", margin: 0, lineHeight: 1.6 }}>
+          エッジデバイスが収集したエネルギーデータをもとに、BCA Green Mark 2021 の基準適合状況を自動で検証します。
+          生の計測値は外部に送信されず、計算結果の正当性のみが改ざん不可能な記録として保存されます。
         </p>
       </div>
 
-      {/* Registry error */}
       {registryError && (
-        <div style={{ color: "#f85149", fontSize: 12, marginBottom: 12 }}>
-          Registry fetch failed: {registryError}
+        <div style={{ color: "#f85149", fontSize: 13, marginBottom: 16 }}>
+          サイト一覧の取得に失敗しました: {registryError}
         </div>
       )}
 
-      {/* E2E 4-quadrant legend */}
-      <QuadrantLegend />
-
-      {/* Operator selector — driven by registry */}
-      <div style={{ marginBottom: 16, display: "flex", alignItems: "center", gap: 10 }}>
-        <label style={{ fontSize: 12, color: "#8b949e" }}>Operator</label>
+      {/* Operator selector */}
+      <div style={{ marginBottom: 20, display: "flex", alignItems: "center", gap: 10 }}>
+        <label style={{ fontSize: 13, color: "#8b949e" }}>事業者</label>
         <select
           value={selectedOperator}
           onChange={e => setSelectedOperator(e.target.value)}
           style={{
             background: "#0d1117", border: "1px solid #30363d", color: "#e6edf3",
-            fontSize: 13, padding: "5px 10px", borderRadius: 6, outline: "none", cursor: "pointer",
+            fontSize: 13, padding: "6px 12px", borderRadius: 6, outline: "none", cursor: "pointer",
           }}
         >
           {Object.entries(operatorSiteMap).map(([opId, sites]) => (
             <option key={opId} value={opId}>
-              {opId} ({sites.length} sites)
+              {opId}（{sites.length} サイト）
             </option>
           ))}
-          {/* Fallback options if registry not loaded */}
           {!registry && operators.map(op => (
             <option key={op.operator_id} value={op.operator_id}>
-              {op.operator_id} ({op.site_count} sites)
+              {op.operator_id}（{op.site_count} サイト）
             </option>
           ))}
         </select>
-        {registry && (
-          <span style={{ fontSize: 11, color: "#8b949e" }}>
-            (source: R2 registry/bca-sites.json)
-          </span>
-        )}
       </div>
 
       {/* Summary banner */}
-      {portfolio && (
-        <div style={{
-          display: "flex", alignItems: "center", gap: 16,
-          padding: "12px 18px", borderRadius: 8, marginBottom: 16,
-          border: tamperCount > 0
-            ? "1px solid rgba(248,81,73,0.6)"
-            : portfolio.all_pass
-            ? "1px solid rgba(63,185,80,0.4)" : "1px solid rgba(210,153,34,0.4)",
-          background: tamperCount > 0
-            ? "rgba(248,81,73,0.07)"
-            : portfolio.all_pass
-            ? "rgba(63,185,80,0.07)" : "rgba(210,153,34,0.07)",
-        }}>
-          <span style={{ fontSize: 22 }}>
-            {tamperCount > 0 ? "🚨" : portfolio.all_pass ? "✅" : "⚠️"}
-          </span>
-          <div>
-            {tamperCount > 0 ? (
-              <>
-                <div style={{ fontWeight: 700, fontSize: 15, color: "#f85149" }}>
-                  {tamperCount} tampered/forged proof{tamperCount > 1 ? "s" : ""} detected — ZKP verification failed
-                </div>
-                <div style={{ fontSize: 12, color: "#8b949e", marginTop: 2 }}>
-                  {portfolio.pass_count}/{portfolio.total_count - tamperCount} honest sites pass BCA Green Mark · {tamperCount} rejected due to invalid proof
-                </div>
-              </>
-            ) : (
-              <>
-                <div style={{ fontWeight: 700, fontSize: 15 }}>
-                  {portfolio.all_pass
-                    ? `Portfolio compliant — ${portfolio.pass_count}/${portfolio.total_count} sites pass BCA Green Mark`
-                    : `${portfolio.pass_count}/${portfolio.total_count} sites passing BCA Green Mark criteria`}
-                </div>
-                <div style={{ fontSize: 12, color: "#8b949e", marginTop: 2 }}>
-                  All proofs verified · Generated {portfolio.generated_at.toISOString().replace("T", " ").slice(0, 19)} UTC
-                </div>
-              </>
-            )}
-          </div>
-          <div style={{ marginLeft: "auto", fontSize: 11, color: "#d29922",
-            background: "rgba(210,153,34,0.1)", border: "1px solid rgba(210,153,34,0.3)",
-            padding: "4px 10px", borderRadius: 12 }}>
-            🔒 Object Lock · deletion not possible
-          </div>
-        </div>
-      )}
+      {portfolio && <SummaryBanner portfolio={portfolio} />}
 
-      {/* Loading state */}
+      {/* Loading */}
       {loading && (
-        <div style={{ color: "#8b949e", fontSize: 13, padding: "40px 0", textAlign: "center" }}>
-          Fetching ZKP attestations from clarus WORM chain…
+        <div style={{ color: "#8b949e", fontSize: 13, padding: "48px 0", textAlign: "center" }}>
+          認証記録を確認中…
         </div>
       )}
 
       {/* Site table */}
       {portfolio && !loading && (
         <div style={{
-          background: "#161b22", border: "1px solid #30363d", borderRadius: 8, overflow: "hidden",
+          background: "#161b22", border: "1px solid #30363d", borderRadius: 10, overflow: "hidden",
         }}>
           <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
             <thead>
               <tr style={{ borderBottom: "1px solid #30363d" }}>
-                {["Site ID", "Cert Level", "All Criteria", "COP", "LPD", "Attested At", "ZKP Proof", ""].map(h => (
-                  <th key={h} style={{
+                {[
+                  { label: "サイト", width: "auto" },
+                  { label: "認証レベル", width: 140 },
+                  { label: "EUI (kWh/m²/年)", width: 130 },
+                  { label: "認証ステータス", width: 160 },
+                  { label: "最終確認日時", width: 130 },
+                  { label: "", width: 32 },
+                ].map(({ label, width }) => (
+                  <th key={label} style={{
                     fontSize: 11, textTransform: "uppercase", letterSpacing: "0.06em",
-                    color: "#8b949e", padding: "8px 12px", textAlign: "left",
-                  }}>{h}</th>
+                    color: "#8b949e", padding: "10px 16px", textAlign: "left", width,
+                  }}>
+                    {label}
+                  </th>
                 ))}
               </tr>
             </thead>
@@ -361,25 +430,22 @@ export function AttestationView({ operators }: Props) {
         </div>
       )}
 
-      {/* API link */}
-      <div style={{ marginTop: 16, fontSize: 11, color: "#8b949e" }}>
-        API:{" "}
+      {/* Note at bottom */}
+      <div style={{
+        marginTop: 20, padding: "12px 16px",
+        background: "rgba(88,166,255,0.04)", border: "1px solid rgba(88,166,255,0.15)",
+        borderRadius: 8, fontSize: 12, color: "#8b949e", lineHeight: 1.6,
+      }}>
+        <span style={{ color: "#58a6ff", fontWeight: 600 }}>ℹ 仕組みについて</span>
+        {" "}各サイトのエッジデバイスが計算した認証結果は、数学的証明とともに改ざん防止ストレージに記録されます。
+        第三者機関（BCA）はこの記録を参照することで、生の計測データを受け取ることなく認証の正当性を確認できます。
         <a
           href={`/api/bca-portfolio/${encodeURIComponent(selectedOperator)}`}
           target="_blank"
           rel="noopener noreferrer"
-          style={{ color: "#58a6ff" }}
+          style={{ color: "#58a6ff", marginLeft: 8 }}
         >
-          /api/bca-portfolio/{selectedOperator}
-        </a>
-        {" · "}
-        <a
-          href="https://clarus.edgesentry.io/data/raw/registry/bca-sites.json"
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: "#58a6ff" }}
-        >
-          registry/bca-sites.json
+          JSON形式で出力 →
         </a>
       </div>
     </div>

--- a/app/src/components/AttestationView.tsx
+++ b/app/src/components/AttestationView.tsx
@@ -1,27 +1,16 @@
 import { useState, useEffect } from "react";
 import {
   fetchPortfolioAttestation,
+  fetchBcaSiteRegistry,
+  sitesByOperator,
   certLevelLabel,
   certLevelColor,
   type PortfolioAttestation,
   type SiteAttestation,
   type CertLevel,
+  type SiteRegistry,
 } from "../lib/attestation.js";
 import type { OperatorSummary } from "../lib/bcaData.js";
-
-// ── Demo site mapping ─────────────────────────────────────────────────────────
-// Maps documaris operator_ids to the clarus site_ids that have ZKP proofs.
-// In production this would come from a site registry.
-const OPERATOR_SITE_MAP: Record<string, string[]> = {
-  "MCH-OPERATOR-001": ["MCH-OUTLET-042"],
-  "MCH-OUTLET-BCA":   ["MCH-OUTLET-042"],
-  "MCH-OUTLET-042":   ["MCH-OUTLET-042"],
-  "ACM-OPERATOR-001": ["ACM-OUTLET-001"],
-};
-
-function fallbackSites(operatorId: string): string[] {
-  return OPERATOR_SITE_MAP[operatorId] ?? [operatorId];
-}
 
 // ── Sub-components ────────────────────────────────────────────────────────────
 
@@ -42,70 +31,101 @@ function CertBadge({ level }: { level: CertLevel }) {
   );
 }
 
+function ProofBadge({ proof_valid }: { proof_valid: boolean | null }) {
+  if (proof_valid === true)  return <span style={{ color: "#3fb950", fontSize: 11, fontWeight: 700 }}>✓ valid</span>;
+  if (proof_valid === false) return <span style={{ color: "#f85149", fontSize: 11, fontWeight: 700 }}>✗ TAMPERED</span>;
+  return <span style={{ color: "#8b949e", fontSize: 11 }}>SP1 (pending)</span>;
+}
+
 function SiteRow({ site }: { site: SiteAttestation }) {
   const [expanded, setExpanded] = useState(false);
   const att = site.attestation;
+  const isTampered = site.proof_valid === false;
 
   return (
     <>
       <tr
         onClick={() => setExpanded(e => !e)}
-        style={{ cursor: "pointer" }}
+        style={{
+          cursor: "pointer",
+          background: isTampered ? "rgba(248,81,73,0.04)" : undefined,
+          borderLeft: isTampered ? "3px solid #f85149" : "3px solid transparent",
+        }}
       >
-        <td style={{ fontFamily: "monospace", fontSize: 12 }}>{site.site_id}</td>
-        <td>
+        <td style={{ fontFamily: "monospace", fontSize: 12, padding: "8px 12px" }}>
+          {site.site_id}
+          {isTampered && (
+            <span style={{
+              marginLeft: 8, fontSize: 10, fontWeight: 700,
+              background: "rgba(248,81,73,0.15)", color: "#f85149",
+              border: "1px solid rgba(248,81,73,0.4)", borderRadius: 8, padding: "1px 6px",
+            }}>
+              ⚠ PROOF INVALID
+            </span>
+          )}
+        </td>
+        <td style={{ padding: "8px 12px" }}>
           {att ? <CertBadge level={att.cert_level} /> : <span style={{ color: "#8b949e", fontSize: 12 }}>—</span>}
         </td>
-        <td style={{ textAlign: "center" }}>
-          {att?.all_criteria_pass === true
+        <td style={{ textAlign: "center", padding: "8px 12px" }}>
+          {att?.all_criteria_pass === true && !isTampered
             ? <span style={{ color: "#3fb950", fontWeight: 700 }}>✓ PASS</span>
+            : att?.all_criteria_pass === true && isTampered
+            ? <span style={{ color: "#f85149", fontWeight: 700 }}>⚠ UNVERIFIED</span>
             : att
             ? <span style={{ color: "#f85149", fontWeight: 700 }}>✗ FAIL</span>
             : <span style={{ color: "#8b949e" }}>—</span>}
         </td>
-        <td style={{ textAlign: "center", fontSize: 12 }}>
+        <td style={{ textAlign: "center", fontSize: 12, padding: "8px 12px" }}>
           {att?.cop_pass === true ? "✓" : att ? "✗" : "—"}
         </td>
-        <td style={{ textAlign: "center", fontSize: 12 }}>
+        <td style={{ textAlign: "center", fontSize: 12, padding: "8px 12px" }}>
           {att?.lpd_pass === true ? "✓" : att ? "✗" : "—"}
         </td>
-        <td style={{ fontFamily: "monospace", fontSize: 12 }}>
+        <td style={{ fontFamily: "monospace", fontSize: 12, padding: "8px 12px" }}>
           {site.attested_at ? site.attested_at.toISOString().replace("T", " ").slice(0, 16) + " UTC" : "—"}
         </td>
-        <td style={{ textAlign: "center" }}>
-          {site.verified
-            ? <span style={{ color: "#3fb950", fontSize: 12 }}>✓ verified</span>
-            : site.error
-            ? <span style={{ color: "#8b949e", fontSize: 12 }}>no proof</span>
-            : "—"}
+        <td style={{ padding: "8px 12px" }}>
+          <ProofBadge proof_valid={site.proof_valid} />
         </td>
-        <td style={{ color: "#58a6ff", fontSize: 12 }}>{expanded ? "▲" : "▼"}</td>
+        <td style={{ color: "#58a6ff", fontSize: 12, padding: "8px 12px" }}>{expanded ? "▲" : "▼"}</td>
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={8} style={{ background: "rgba(88,166,255,0.04)", padding: "12px 16px" }}>
+          <td colSpan={8} style={{ background: "rgba(88,166,255,0.04)", padding: "12px 16px", borderBottom: "1px solid #30363d" }}>
             {att ? (
-              <div style={{ display: "grid", gridTemplateColumns: "180px 1fr", gap: "4px 12px", fontSize: 12 }}>
+              <div style={{ display: "grid", gridTemplateColumns: "220px 1fr", gap: "4px 12px", fontSize: 12 }}>
                 <span style={{ color: "#8b949e" }}>EUI</span>
                 <span style={{ fontFamily: "monospace" }}>{att.eui_kwh_m2.toFixed(1)} kWh/m²/year</span>
                 <span style={{ color: "#8b949e" }}>COP pass (≥ 0.65)</span>
                 <span style={{ color: att.cop_pass ? "#3fb950" : "#f85149" }}>{att.cop_pass ? "Yes" : "No"}</span>
                 <span style={{ color: "#8b949e" }}>LPD pass (≤ 15 W/m²)</span>
                 <span style={{ color: att.lpd_pass ? "#3fb950" : "#f85149" }}>{att.lpd_pass ? "Yes" : "No"}</span>
-                <span style={{ color: "#8b949e" }}>Record hash</span>
-                <span style={{ fontFamily: "monospace", wordBreak: "break-all", color: "#8b949e" }}>
-                  {site.record_hash ?? "—"}
+                <span style={{ color: "#8b949e" }}>ZK proof verification</span>
+                <span>
+                  {site.proof_valid === true  && <span style={{ color: "#3fb950" }}>✓ BLAKE3 hash matches public_values — proof authentic</span>}
+                  {site.proof_valid === false && (
+                    <span style={{ color: "#f85149" }}>
+                      ✗ BLAKE3 hash does NOT match — proof_bytes are tampered or forged.
+                      This record cannot be trusted regardless of the claimed cert_level.
+                    </span>
+                  )}
+                  {site.proof_valid === null  && <span style={{ color: "#8b949e" }}>SP1 Groth16 verification pending WASM verifier integration</span>}
                 </span>
                 <span style={{ color: "#8b949e" }}>ZK framework</span>
                 <span style={{ fontFamily: "monospace" }}>mock (SP1 pending)</span>
+                <span style={{ color: "#8b949e" }}>Record hash</span>
+                <span style={{ fontFamily: "monospace", wordBreak: "break-all", color: "#8b949e", fontSize: 11 }}>
+                  {site.record_hash ?? "—"}
+                </span>
                 <span style={{ color: "#8b949e" }}>Raw sensor data</span>
                 <span style={{ color: "#3fb950" }}>Not exposed — stays on edge device ✓</span>
               </div>
             ) : (
               <span style={{ color: "#8b949e", fontSize: 12 }}>
-                {site.error === "no_runs"
+                {site.error === "no runs"
                   ? "No audit records found. Run clarus-edge with PROFILE=sg-bca-greenmark."
-                  : site.error === "no_zkp_record"
+                  : site.error === "no zk_proof in recent records"
                   ? "No ZKP-bearing records in the most recent run."
                   : `Error: ${site.error}`}
               </span>
@@ -117,6 +137,34 @@ function SiteRow({ site }: { site: SiteAttestation }) {
   );
 }
 
+// ── 4-quadrant legend ─────────────────────────────────────────────────────────
+
+function QuadrantLegend() {
+  const cell = (label: string, color: string, bg: string) => (
+    <div style={{
+      padding: "10px 14px", borderRadius: 6,
+      border: `1px solid ${color}44`,
+      background: bg, fontSize: 11,
+    }}>
+      <div style={{ fontWeight: 700, color, marginBottom: 3 }}>{label}</div>
+    </div>
+  );
+
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <div style={{ fontSize: 11, color: "#8b949e", marginBottom: 6 }}>
+        E2E test matrix — all 4 quadrants of ZKP computation × BCA criteria:
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, maxWidth: 560 }}>
+        {cell("Q1 ✓ Correct calc + Passes BCA GM",   "#3fb950", "rgba(63,185,80,0.06)")}
+        {cell("Q2 ✓ Correct calc + Fails BCA GM",    "#d29922", "rgba(210,153,34,0.06)")}
+        {cell("Q3 ✗ Tampered ZKP + Claims PASS → fraud detected",  "#f85149", "rgba(248,81,73,0.06)")}
+        {cell("Q4 ✗ Tampered ZKP + Claims FAIL → sabotage detected", "#f85149", "rgba(248,81,73,0.06)")}
+      </div>
+    </div>
+  );
+}
+
 // ── Main view ─────────────────────────────────────────────────────────────────
 
 interface Props {
@@ -124,24 +172,44 @@ interface Props {
 }
 
 export function AttestationView({ operators }: Props) {
-  const [selectedOperator, setSelectedOperator] = useState<string>(
-    operators[0]?.operator_id ?? "MCH-OUTLET-042"
-  );
-  const [portfolio, setPortfolio] = useState<PortfolioAttestation | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [registry, setRegistry]           = useState<SiteRegistry | null>(null);
+  const [registryError, setRegistryError] = useState<string | null>(null);
+  const [selectedOperator, setSelectedOperator] = useState<string>("MCH-OPERATOR-001");
+  const [portfolio, setPortfolio]         = useState<PortfolioAttestation | null>(null);
+  const [loading, setLoading]             = useState(false);
 
+  // Fetch registry from R2 on mount
   useEffect(() => {
-    if (!selectedOperator) return;
+    fetchBcaSiteRegistry()
+      .then(setRegistry)
+      .catch(e => setRegistryError(String(e)));
+  }, []);
+
+  // Derive operator → site_id mapping from registry
+  const operatorSiteMap = registry ? sitesByOperator(registry) : {};
+
+  // Set default operator from registry once loaded
+  useEffect(() => {
+    if (registry && registry.sites.length > 0 && !operatorSiteMap[selectedOperator]) {
+      setSelectedOperator(Object.keys(operatorSiteMap)[0]);
+    }
+  }, [registry]);
+
+  // Fetch attestations whenever selected operator changes
+  useEffect(() => {
+    const siteIds = operatorSiteMap[selectedOperator];
+    if (!siteIds?.length) return;
     setLoading(true);
     setPortfolio(null);
-    const siteIds = fallbackSites(selectedOperator);
     fetchPortfolioAttestation(selectedOperator, siteIds)
       .then(setPortfolio)
       .finally(() => setLoading(false));
-  }, [selectedOperator]);
+  }, [selectedOperator, registry]);
+
+  const tamperCount = portfolio?.sites.filter(s => s.proof_valid === false).length ?? 0;
 
   return (
-    <div style={{ padding: "24px", maxWidth: 1000, margin: "0 auto" }}>
+    <div style={{ padding: "24px", maxWidth: 1100, margin: "0 auto" }}>
 
       {/* Header */}
       <div style={{ marginBottom: 20 }}>
@@ -156,57 +224,102 @@ export function AttestationView({ operators }: Props) {
           }}>
             WORM-sealed · proof-backed
           </span>
+          {registry && (
+            <span style={{
+              background: "rgba(88,166,255,0.1)", color: "#58a6ff",
+              border: "1px solid rgba(88,166,255,0.3)", borderRadius: 12,
+              fontSize: 11, padding: "2px 10px",
+            }}>
+              {registry.sites.length} sites from R2 registry
+            </span>
+          )}
         </div>
         <p style={{ fontSize: 12, color: "#8b949e", margin: 0 }}>
           Compliance status derived from ZKP proofs in the clarus WORM audit chain.
-          Raw sensor data (EUI readings, occupancy, area) is never transmitted — only the mathematical attestation is read.
+          Raw sensor data (EUI readings, occupancy, area) never transmitted — only the mathematical attestation is read.
+          Proof bytes verified in-browser via BLAKE3.
         </p>
       </div>
 
-      {/* Operator selector */}
-      {operators.length > 0 && (
-        <div style={{ marginBottom: 16, display: "flex", alignItems: "center", gap: 10 }}>
-          <label style={{ fontSize: 12, color: "#8b949e" }}>Operator</label>
-          <select
-            value={selectedOperator}
-            onChange={e => setSelectedOperator(e.target.value)}
-            style={{
-              background: "#0d1117", border: "1px solid #30363d", color: "#e6edf3",
-              fontSize: 13, padding: "5px 10px", borderRadius: 6, outline: "none", cursor: "pointer",
-            }}
-          >
-            {operators.map(op => (
-              <option key={op.operator_id} value={op.operator_id}>
-                {op.operator_id} ({op.site_count} sites)
-              </option>
-            ))}
-            <option value="MCH-OUTLET-042">MCH-OUTLET-042 (demo)</option>
-            <option value="ACM-OUTLET-001">ACM-OUTLET-001 (demo)</option>
-          </select>
+      {/* Registry error */}
+      {registryError && (
+        <div style={{ color: "#f85149", fontSize: 12, marginBottom: 12 }}>
+          Registry fetch failed: {registryError}
         </div>
       )}
+
+      {/* E2E 4-quadrant legend */}
+      <QuadrantLegend />
+
+      {/* Operator selector — driven by registry */}
+      <div style={{ marginBottom: 16, display: "flex", alignItems: "center", gap: 10 }}>
+        <label style={{ fontSize: 12, color: "#8b949e" }}>Operator</label>
+        <select
+          value={selectedOperator}
+          onChange={e => setSelectedOperator(e.target.value)}
+          style={{
+            background: "#0d1117", border: "1px solid #30363d", color: "#e6edf3",
+            fontSize: 13, padding: "5px 10px", borderRadius: 6, outline: "none", cursor: "pointer",
+          }}
+        >
+          {Object.entries(operatorSiteMap).map(([opId, sites]) => (
+            <option key={opId} value={opId}>
+              {opId} ({sites.length} sites)
+            </option>
+          ))}
+          {/* Fallback options if registry not loaded */}
+          {!registry && operators.map(op => (
+            <option key={op.operator_id} value={op.operator_id}>
+              {op.operator_id} ({op.site_count} sites)
+            </option>
+          ))}
+        </select>
+        {registry && (
+          <span style={{ fontSize: 11, color: "#8b949e" }}>
+            (source: R2 registry/bca-sites.json)
+          </span>
+        )}
+      </div>
 
       {/* Summary banner */}
       {portfolio && (
         <div style={{
           display: "flex", alignItems: "center", gap: 16,
           padding: "12px 18px", borderRadius: 8, marginBottom: 16,
-          border: portfolio.all_pass
-            ? "1px solid rgba(63,185,80,0.4)" : "1px solid rgba(248,81,73,0.4)",
-          background: portfolio.all_pass
-            ? "rgba(63,185,80,0.07)" : "rgba(248,81,73,0.07)",
+          border: tamperCount > 0
+            ? "1px solid rgba(248,81,73,0.6)"
+            : portfolio.all_pass
+            ? "1px solid rgba(63,185,80,0.4)" : "1px solid rgba(210,153,34,0.4)",
+          background: tamperCount > 0
+            ? "rgba(248,81,73,0.07)"
+            : portfolio.all_pass
+            ? "rgba(63,185,80,0.07)" : "rgba(210,153,34,0.07)",
         }}>
-          <span style={{ fontSize: 22 }}>{portfolio.all_pass ? "✅" : "⚠️"}</span>
+          <span style={{ fontSize: 22 }}>
+            {tamperCount > 0 ? "🚨" : portfolio.all_pass ? "✅" : "⚠️"}
+          </span>
           <div>
-            <div style={{ fontWeight: 700, fontSize: 15 }}>
-              {portfolio.all_pass
-                ? `Portfolio compliant — ${portfolio.pass_count}/${portfolio.total_count} sites pass BCA Green Mark`
-                : `${portfolio.pass_count}/${portfolio.total_count} sites passing BCA Green Mark criteria`}
-            </div>
-            <div style={{ fontSize: 12, color: "#8b949e", marginTop: 2 }}>
-              Generated {portfolio.generated_at.toISOString().replace("T", " ").slice(0, 19)} UTC
-              · Operator: {portfolio.operator_id}
-            </div>
+            {tamperCount > 0 ? (
+              <>
+                <div style={{ fontWeight: 700, fontSize: 15, color: "#f85149" }}>
+                  {tamperCount} tampered/forged proof{tamperCount > 1 ? "s" : ""} detected — ZKP verification failed
+                </div>
+                <div style={{ fontSize: 12, color: "#8b949e", marginTop: 2 }}>
+                  {portfolio.pass_count}/{portfolio.total_count - tamperCount} honest sites pass BCA Green Mark · {tamperCount} rejected due to invalid proof
+                </div>
+              </>
+            ) : (
+              <>
+                <div style={{ fontWeight: 700, fontSize: 15 }}>
+                  {portfolio.all_pass
+                    ? `Portfolio compliant — ${portfolio.pass_count}/${portfolio.total_count} sites pass BCA Green Mark`
+                    : `${portfolio.pass_count}/${portfolio.total_count} sites passing BCA Green Mark criteria`}
+                </div>
+                <div style={{ fontSize: 12, color: "#8b949e", marginTop: 2 }}>
+                  All proofs verified · Generated {portfolio.generated_at.toISOString().replace("T", " ").slice(0, 19)} UTC
+                </div>
+              </>
+            )}
           </div>
           <div style={{ marginLeft: "auto", fontSize: 11, color: "#d29922",
             background: "rgba(210,153,34,0.1)", border: "1px solid rgba(210,153,34,0.3)",
@@ -231,7 +344,7 @@ export function AttestationView({ operators }: Props) {
           <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
             <thead>
               <tr style={{ borderBottom: "1px solid #30363d" }}>
-                {["Site ID", "Cert Level", "All Criteria", "COP", "LPD", "Attested At", "Proof", ""].map(h => (
+                {["Site ID", "Cert Level", "All Criteria", "COP", "LPD", "Attested At", "ZKP Proof", ""].map(h => (
                   <th key={h} style={{
                     fontSize: 11, textTransform: "uppercase", letterSpacing: "0.06em",
                     color: "#8b949e", padding: "8px 12px", textAlign: "left",
@@ -250,7 +363,8 @@ export function AttestationView({ operators }: Props) {
 
       {/* API link */}
       <div style={{ marginTop: 16, fontSize: 11, color: "#8b949e" }}>
-        API: <a
+        API:{" "}
+        <a
           href={`/api/bca-portfolio/${encodeURIComponent(selectedOperator)}`}
           target="_blank"
           rel="noopener noreferrer"
@@ -258,7 +372,15 @@ export function AttestationView({ operators }: Props) {
         >
           /api/bca-portfolio/{selectedOperator}
         </a>
-        {" "}→ raw JSON attestation (for BCA integration / downstream systems)
+        {" · "}
+        <a
+          href="https://clarus.edgesentry.io/data/raw/registry/bca-sites.json"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: "#58a6ff" }}
+        >
+          registry/bca-sites.json
+        </a>
       </div>
     </div>
   );

--- a/app/src/components/AttestationView.tsx
+++ b/app/src/components/AttestationView.tsx
@@ -101,16 +101,18 @@ function SiteRow({ site }: { site: SiteAttestation }) {
         {/* Site */}
         <td style={{ padding: "12px 16px" }}>
           <div style={{ fontSize: 13, fontWeight: 600, fontFamily: "monospace" }}>{site.site_id}</div>
-          {att && (
-            <div style={{ fontSize: 11, color: "#8b949e", marginTop: 2 }}>
-              {CERT_DESCRIPTIONS[att.cert_level]}
-            </div>
-          )}
         </td>
 
         {/* Certification level */}
         <td style={{ padding: "12px 16px" }}>
-          {att ? <CertBadge level={att.cert_level} /> : <span style={{ color: "#8b949e", fontSize: 12 }}>—</span>}
+          {att ? (
+            <>
+              <CertBadge level={att.cert_level} />
+              <div style={{ fontSize: 11, color: "#8b949e", marginTop: 4 }}>
+                {CERT_DESCRIPTIONS[att.cert_level]}
+              </div>
+            </>
+          ) : <span style={{ color: "#8b949e", fontSize: 12 }}>—</span>}
         </td>
 
         {/* EUI */}

--- a/app/src/components/AttestationView.tsx
+++ b/app/src/components/AttestationView.tsx
@@ -15,11 +15,11 @@ import type { OperatorSummary } from "../lib/bcaData.js";
 // ── Cert level display ────────────────────────────────────────────────────────
 
 const CERT_DESCRIPTIONS: Record<CertLevel, string> = {
-  platinum:      "BCA Green Mark Platinum — 最高水準のエネルギー効率",
-  gold_plus:     "BCA Green Mark GoldPlus — 優秀なエネルギー効率",
-  gold:          "BCA Green Mark Gold — 良好なエネルギー効率",
-  certified:     "BCA Green Mark Certified — 基準を満たす",
-  not_certified: "非認定 — BCA基準を満たしていません",
+  platinum:      "Highest energy efficiency — BCA Green Mark Platinum",
+  gold_plus:     "Excellent energy efficiency — BCA Green Mark GoldPlus",
+  gold:          "Good energy efficiency — BCA Green Mark Gold",
+  certified:     "Meets the BCA Green Mark standard — Certified",
+  not_certified: "Does not meet BCA Green Mark requirements",
 };
 
 function CertBadge({ level }: { level: CertLevel }) {
@@ -39,46 +39,46 @@ function CertBadge({ level }: { level: CertLevel }) {
   );
 }
 
-// ── Trust status badge ────────────────────────────────────────────────────────
+// ── Compliance status ─────────────────────────────────────────────────────────
 
-function TrustBadge({ proof_valid, all_criteria_pass }: { proof_valid: boolean | null; all_criteria_pass: boolean | undefined }) {
+function StatusBadge({ proof_valid, all_criteria_pass }: { proof_valid: boolean | null; all_criteria_pass: boolean | undefined }) {
   if (proof_valid === false) {
     return (
       <span style={{
-        display: "inline-flex", alignItems: "center", gap: 4,
+        display: "inline-flex", alignItems: "center", gap: 5,
         color: "#f85149", fontSize: 12, fontWeight: 700,
         background: "rgba(248,81,73,0.12)", border: "1px solid rgba(248,81,73,0.4)",
         borderRadius: 10, padding: "3px 10px",
       }}>
-        ⚠ データ信頼性に問題あり
+        ⚠ Data integrity issue
       </span>
     );
   }
   if (all_criteria_pass === true) {
     return (
       <span style={{
-        display: "inline-flex", alignItems: "center", gap: 4,
+        display: "inline-flex", alignItems: "center", gap: 5,
         color: "#3fb950", fontSize: 12, fontWeight: 700,
         background: "rgba(63,185,80,0.12)", border: "1px solid rgba(63,185,80,0.4)",
         borderRadius: 10, padding: "3px 10px",
       }}>
-        ✓ 認証取得済み
+        ✓ Certified
       </span>
     );
   }
   if (all_criteria_pass === false) {
     return (
       <span style={{
-        display: "inline-flex", alignItems: "center", gap: 4,
+        display: "inline-flex", alignItems: "center", gap: 5,
         color: "#d29922", fontSize: 12, fontWeight: 600,
         background: "rgba(210,153,34,0.12)", border: "1px solid rgba(210,153,34,0.4)",
         borderRadius: 10, padding: "3px 10px",
       }}>
-        — 基準未達
+        — Below standard
       </span>
     );
   }
-  return <span style={{ color: "#8b949e", fontSize: 12 }}>確認中</span>;
+  return <span style={{ color: "#8b949e", fontSize: 12 }}>Pending</span>;
 }
 
 // ── Site row ──────────────────────────────────────────────────────────────────
@@ -98,7 +98,7 @@ function SiteRow({ site }: { site: SiteAttestation }) {
           borderLeft: isTampered ? "3px solid #f85149" : "3px solid transparent",
         }}
       >
-        {/* Site name */}
+        {/* Site */}
         <td style={{ padding: "12px 16px" }}>
           <div style={{ fontSize: 13, fontWeight: 600, fontFamily: "monospace" }}>{site.site_id}</div>
           {att && (
@@ -122,16 +122,15 @@ function SiteRow({ site }: { site: SiteAttestation }) {
           ) : "—"}
         </td>
 
-        {/* Compliance status */}
+        {/* Status */}
         <td style={{ padding: "12px 16px" }}>
-          <TrustBadge proof_valid={site.proof_valid} all_criteria_pass={att?.all_criteria_pass} />
+          <StatusBadge proof_valid={site.proof_valid} all_criteria_pass={att?.all_criteria_pass} />
         </td>
 
-        {/* Last verified */}
+        {/* Verified at */}
         <td style={{ padding: "12px 16px", fontSize: 12, color: "#8b949e" }}>
           {site.attested_at
-            ? site.attested_at.toLocaleDateString("ja-JP", { year: "numeric", month: "2-digit", day: "2-digit" })
-              + " " + site.attested_at.toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" })
+            ? site.attested_at.toISOString().slice(0, 16).replace("T", " ") + " UTC"
             : "—"}
         </td>
 
@@ -147,84 +146,82 @@ function SiteRow({ site }: { site: SiteAttestation }) {
             borderBottom: "1px solid #30363d",
           }}>
             {att ? (
-              <div style={{ display: "flex", gap: 32, flexWrap: "wrap" }}>
+              <div style={{ display: "flex", gap: 40, flexWrap: "wrap" }}>
 
-                {/* Criteria detail */}
+                {/* Criteria */}
                 <div>
                   <div style={{ fontSize: 11, color: "#8b949e", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 10 }}>
-                    BCA基準チェック項目
+                    BCA Compliance Criteria
                   </div>
-                  <div style={{ display: "grid", gridTemplateColumns: "auto auto", gap: "6px 20px", fontSize: 13 }}>
-                    <span style={{ color: "#8b949e" }}>エネルギー使用強度（EUI）</span>
-                    <span style={{ color: att.cop_pass ? "#e6edf3" : "#f85149" }}>
-                      {att.eui_kwh_m2.toFixed(1)} kWh/m²/年
+                  <div style={{ display: "grid", gridTemplateColumns: "auto auto", gap: "6px 24px", fontSize: 13 }}>
+                    <span style={{ color: "#8b949e" }}>Energy Use Intensity (EUI)</span>
+                    <span>
+                      {att.eui_kwh_m2.toFixed(1)} kWh/m²/yr
                       <span style={{ marginLeft: 8, fontSize: 11, color: certLevelColor(att.cert_level) }}>
                         ({certLevelLabel(att.cert_level)})
                       </span>
                     </span>
 
-                    <span style={{ color: "#8b949e" }}>冷凍機効率（COP）</span>
+                    <span style={{ color: "#8b949e" }}>Chiller Efficiency (COP)</span>
                     <span style={{ color: att.cop_pass ? "#3fb950" : "#f85149" }}>
-                      {att.cop_pass ? "✓ 基準達成（≥ 0.65）" : "✗ 基準未達（< 0.65）"}
+                      {att.cop_pass ? "✓ Meets standard (≥ 0.65)" : "✗ Below standard (< 0.65)"}
                     </span>
 
-                    <span style={{ color: "#8b949e" }}>照明電力密度（LPD）</span>
+                    <span style={{ color: "#8b949e" }}>Lighting Power Density (LPD)</span>
                     <span style={{ color: att.lpd_pass ? "#3fb950" : "#f85149" }}>
-                      {att.lpd_pass ? "✓ 基準達成（≤ 15 W/m²）" : "✗ 基準未達（> 15 W/m²）"}
+                      {att.lpd_pass ? "✓ Meets standard (≤ 15 W/m²)" : "✗ Above limit (> 15 W/m²)"}
                     </span>
                   </div>
                 </div>
 
                 {/* Data integrity */}
-                <div>
+                <div style={{ maxWidth: 340 }}>
                   <div style={{ fontSize: 11, color: "#8b949e", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 10 }}>
-                    データの信頼性
+                    Data Integrity
                   </div>
-                  <div style={{ fontSize: 13 }}>
-                    {site.proof_valid === true && (
-                      <div style={{ color: "#3fb950" }}>
-                        ✓ 数値が改ざんされていないことを数学的に検証済み
-                        <div style={{ fontSize: 11, color: "#8b949e", marginTop: 4 }}>
-                          エネルギー計算の元データ（生センサー値）はエッジデバイス内に保持され、
-                          外部に送信されることなく、計算結果のみが認証記録として保存されています。
-                        </div>
+                  {site.proof_valid === true && (
+                    <div style={{ fontSize: 13, color: "#3fb950" }}>
+                      ✓ Figures verified — not altered since measurement
+                      <div style={{ fontSize: 11, color: "#8b949e", marginTop: 4, lineHeight: 1.5 }}>
+                        Raw sensor data stays on the edge device and is never transmitted.
+                        Only the computed result — with a mathematical proof of correctness — is stored in the audit record.
                       </div>
-                    )}
-                    {site.proof_valid === false && (
-                      <div style={{ color: "#f85149" }}>
-                        ⚠ 認証データの整合性が確認できません
-                        <div style={{ fontSize: 11, color: "#f85149", marginTop: 4, opacity: 0.8 }}>
-                          申告されている認証レベルと、実際の計算証明が一致していません。
-                          このデータに基づいて認証を発行することはできません。
-                        </div>
+                    </div>
+                  )}
+                  {site.proof_valid === false && (
+                    <div style={{ fontSize: 13, color: "#f85149" }}>
+                      ⚠ Cannot confirm data integrity
+                      <div style={{ fontSize: 11, color: "#f85149", opacity: 0.85, marginTop: 4, lineHeight: 1.5 }}>
+                        The claimed certification level does not match the mathematical proof attached to this record.
+                        This submission cannot be used as the basis for issuing a Green Mark certificate.
                       </div>
-                    )}
-                    {site.proof_valid === null && (
-                      <div style={{ color: "#8b949e" }}>
-                        次世代の検証方式（SP1）への移行準備中です。現在は自動確認できません。
-                      </div>
-                    )}
-                  </div>
+                    </div>
+                  )}
+                  {site.proof_valid === null && (
+                    <div style={{ fontSize: 13, color: "#8b949e" }}>
+                      Automatic verification not yet available for this proof type.
+                    </div>
+                  )}
                 </div>
 
                 {/* Audit trail */}
                 <div>
                   <div style={{ fontSize: 11, color: "#8b949e", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 10 }}>
-                    監査記録
+                    Audit Record
                   </div>
-                  <div style={{ fontSize: 12, color: "#8b949e" }}>
-                    <div>記録ID: <span style={{ fontFamily: "monospace", fontSize: 11 }}>{site.record_hash?.slice(0, 16) ?? "—"}…</span></div>
-                    <div style={{ marginTop: 4 }}>この記録は改ざん防止ストレージに保存されており、後から変更・削除することはできません。</div>
+                  <div style={{ fontSize: 12, color: "#8b949e", lineHeight: 1.6 }}>
+                    <div>Record ID: <span style={{ fontFamily: "monospace", fontSize: 11 }}>{site.record_hash?.slice(0, 16) ?? "—"}…</span></div>
+                    <div style={{ marginTop: 4 }}>Stored in tamper-evident, deletion-proof storage. Cannot be modified after the fact.</div>
                   </div>
                 </div>
               </div>
             ) : (
               <div style={{ color: "#8b949e", fontSize: 13 }}>
                 {site.error === "no runs"
-                  ? "このサイトの認証記録がまだありません。"
+                  ? "No certification records found for this site."
                   : site.error === "no zk_proof in recent records"
-                  ? "直近の記録に認証データが含まれていません。"
-                  : `データ取得エラー: ${site.error}`}
+                  ? "The most recent record does not include a certification proof."
+                  : `Could not retrieve data: ${site.error}`}
               </div>
             )}
           </td>
@@ -237,10 +234,9 @@ function SiteRow({ site }: { site: SiteAttestation }) {
 // ── Summary banner ────────────────────────────────────────────────────────────
 
 function SummaryBanner({ portfolio }: { portfolio: PortfolioAttestation }) {
-  const tamperCount  = portfolio.sites.filter(s => s.proof_valid === false).length;
-  const passCount    = portfolio.pass_count;
-  const total        = portfolio.total_count;
-  const honestTotal  = total - tamperCount;
+  const tamperCount = portfolio.sites.filter(s => s.proof_valid === false).length;
+  const passCount   = portfolio.pass_count;
+  const total       = portfolio.total_count;
 
   if (tamperCount > 0) {
     return (
@@ -251,17 +247,17 @@ function SummaryBanner({ portfolio }: { portfolio: PortfolioAttestation }) {
         <span style={{ fontSize: 24, lineHeight: 1 }}>🚨</span>
         <div>
           <div style={{ fontWeight: 700, fontSize: 15, color: "#f85149" }}>
-            {tamperCount}件のデータ申告に問題が検出されました
+            {tamperCount} submission{tamperCount > 1 ? "s" : ""} could not be verified
           </div>
           <div style={{ fontSize: 13, color: "#8b949e", marginTop: 4 }}>
-            信頼性が確認できた {honestTotal} 件のうち、{passCount} 件が BCA Green Mark 基準を満たしています。
-            問題のある申告は認証対象から除外されます。
+            Of the {total - tamperCount} verified submissions, {passCount} meet{passCount === 1 ? "s" : ""} the BCA Green Mark standard.
+            Unverified submissions are excluded from certification.
           </div>
         </div>
         <div style={{ marginLeft: "auto", alignSelf: "center", fontSize: 11, color: "#d29922",
           background: "rgba(210,153,34,0.1)", border: "1px solid rgba(210,153,34,0.3)",
           padding: "4px 12px", borderRadius: 12, whiteSpace: "nowrap" }}>
-          🔒 記録は削除・変更不可
+          🔒 Records cannot be deleted or altered
         </div>
       </div>
     );
@@ -279,18 +275,18 @@ function SummaryBanner({ portfolio }: { portfolio: PortfolioAttestation }) {
       <div>
         <div style={{ fontWeight: 700, fontSize: 15 }}>
           {portfolio.all_pass
-            ? `全 ${total} 件が BCA Green Mark 基準を達成しています`
-            : `${total} 件中 ${passCount} 件が BCA Green Mark 基準を達成しています`}
+            ? `All ${total} sites meet the BCA Green Mark standard`
+            : `${passCount} of ${total} sites meet the BCA Green Mark standard`}
         </div>
         <div style={{ fontSize: 13, color: "#8b949e", marginTop: 4 }}>
-          すべての認証データの整合性が確認されています ·
-          確認日時: {portfolio.generated_at.toLocaleString("ja-JP")}
+          All data integrity checks passed ·
+          Verified {portfolio.generated_at.toISOString().slice(0, 16).replace("T", " ")} UTC
         </div>
       </div>
       <div style={{ marginLeft: "auto", alignSelf: "center", fontSize: 11, color: "#d29922",
         background: "rgba(210,153,34,0.1)", border: "1px solid rgba(210,153,34,0.3)",
         padding: "4px 12px", borderRadius: 12, whiteSpace: "nowrap" }}>
-        🔒 記録は削除・変更不可
+        🔒 Records cannot be deleted or altered
       </div>
     </div>
   );
@@ -340,31 +336,31 @@ export function AttestationView({ operators }: Props) {
       <div style={{ marginBottom: 24 }}>
         <div style={{ display: "flex", alignItems: "baseline", gap: 12, marginBottom: 8 }}>
           <h2 style={{ fontSize: 18, fontWeight: 700, margin: 0 }}>
-            BCA Green Mark 認証ポートフォリオ
+            BCA Green Mark Portfolio
           </h2>
           <span style={{
             background: "rgba(63,185,80,0.1)", color: "#3fb950",
             border: "1px solid rgba(63,185,80,0.3)", borderRadius: 12,
             fontSize: 11, fontWeight: 700, padding: "2px 10px",
           }}>
-            改ざん防止記録
+            Tamper-proof records
           </span>
         </div>
         <p style={{ fontSize: 13, color: "#8b949e", margin: 0, lineHeight: 1.6 }}>
-          エッジデバイスが収集したエネルギーデータをもとに、BCA Green Mark 2021 の基準適合状況を自動で検証します。
-          生の計測値は外部に送信されず、計算結果の正当性のみが改ざん不可能な記録として保存されます。
+          Compliance status verified automatically from energy data collected at each site.
+          Raw measurements stay on the device — only the computed result, with proof that the calculation is correct, is stored in the audit record.
         </p>
       </div>
 
       {registryError && (
         <div style={{ color: "#f85149", fontSize: 13, marginBottom: 16 }}>
-          サイト一覧の取得に失敗しました: {registryError}
+          Could not load site list: {registryError}
         </div>
       )}
 
       {/* Operator selector */}
       <div style={{ marginBottom: 20, display: "flex", alignItems: "center", gap: 10 }}>
-        <label style={{ fontSize: 13, color: "#8b949e" }}>事業者</label>
+        <label style={{ fontSize: 13, color: "#8b949e" }}>Operator</label>
         <select
           value={selectedOperator}
           onChange={e => setSelectedOperator(e.target.value)}
@@ -375,12 +371,12 @@ export function AttestationView({ operators }: Props) {
         >
           {Object.entries(operatorSiteMap).map(([opId, sites]) => (
             <option key={opId} value={opId}>
-              {opId}（{sites.length} サイト）
+              {opId} ({sites.length} site{sites.length !== 1 ? "s" : ""})
             </option>
           ))}
           {!registry && operators.map(op => (
             <option key={op.operator_id} value={op.operator_id}>
-              {op.operator_id}（{op.site_count} サイト）
+              {op.operator_id} ({op.site_count} site{op.site_count !== 1 ? "s" : ""})
             </option>
           ))}
         </select>
@@ -392,7 +388,7 @@ export function AttestationView({ operators }: Props) {
       {/* Loading */}
       {loading && (
         <div style={{ color: "#8b949e", fontSize: 13, padding: "48px 0", textAlign: "center" }}>
-          認証記録を確認中…
+          Retrieving certification records…
         </div>
       )}
 
@@ -405,16 +401,16 @@ export function AttestationView({ operators }: Props) {
             <thead>
               <tr style={{ borderBottom: "1px solid #30363d" }}>
                 {[
-                  { label: "サイト", width: "auto" },
-                  { label: "認証レベル", width: 140 },
-                  { label: "EUI (kWh/m²/年)", width: 130 },
-                  { label: "認証ステータス", width: 160 },
-                  { label: "最終確認日時", width: 130 },
-                  { label: "", width: 32 },
-                ].map(({ label, width }) => (
+                  "Site",
+                  "Certification Level",
+                  "EUI (kWh/m²/yr)",
+                  "Status",
+                  "Verified At",
+                  "",
+                ].map(label => (
                   <th key={label} style={{
                     fontSize: 11, textTransform: "uppercase", letterSpacing: "0.06em",
-                    color: "#8b949e", padding: "10px 16px", textAlign: "left", width,
+                    color: "#8b949e", padding: "10px 16px", textAlign: "left",
                   }}>
                     {label}
                   </th>
@@ -430,22 +426,23 @@ export function AttestationView({ operators }: Props) {
         </div>
       )}
 
-      {/* Note at bottom */}
+      {/* Footer note */}
       <div style={{
         marginTop: 20, padding: "12px 16px",
         background: "rgba(88,166,255,0.04)", border: "1px solid rgba(88,166,255,0.15)",
         borderRadius: 8, fontSize: 12, color: "#8b949e", lineHeight: 1.6,
       }}>
-        <span style={{ color: "#58a6ff", fontWeight: 600 }}>ℹ 仕組みについて</span>
-        {" "}各サイトのエッジデバイスが計算した認証結果は、数学的証明とともに改ざん防止ストレージに記録されます。
-        第三者機関（BCA）はこの記録を参照することで、生の計測データを受け取ることなく認証の正当性を確認できます。
+        <span style={{ color: "#58a6ff", fontWeight: 600 }}>How this works</span>
+        {" — "}
+        Each site's edge device computes the energy compliance result and stores it with a mathematical proof in a tamper-evident record.
+        BCA can verify the result without ever receiving the raw sensor data.
         <a
           href={`/api/bca-portfolio/${encodeURIComponent(selectedOperator)}`}
           target="_blank"
           rel="noopener noreferrer"
           style={{ color: "#58a6ff", marginLeft: 8 }}
         >
-          JSON形式で出力 →
+          Export as JSON →
         </a>
       </div>
     </div>

--- a/app/src/components/AttestationView.tsx
+++ b/app/src/components/AttestationView.tsx
@@ -294,6 +294,119 @@ function SummaryBanner({ portfolio }: { portfolio: PortfolioAttestation }) {
   );
 }
 
+// ── Filter bar ────────────────────────────────────────────────────────────────
+
+type StatusFilter = "all" | "certified" | "below_standard" | "integrity_issue" | "no_records";
+
+const STATUS_FILTERS: { key: StatusFilter; label: string }[] = [
+  { key: "all",             label: "All" },
+  { key: "certified",       label: "✓ Certified" },
+  { key: "below_standard",  label: "Below standard" },
+  { key: "integrity_issue", label: "⚠ Data integrity issue" },
+  { key: "no_records",      label: "No records" },
+];
+
+function matchesStatusFilter(site: SiteAttestation, filter: StatusFilter): boolean {
+  if (filter === "all")             return true;
+  if (filter === "integrity_issue") return site.proof_valid === false;
+  if (filter === "no_records")      return site.attestation === null;
+  if (filter === "certified")       return site.attestation?.all_criteria_pass === true && site.proof_valid !== false;
+  if (filter === "below_standard")  return site.attestation?.all_criteria_pass === false && site.proof_valid !== false;
+  return true;
+}
+
+function applySiteFilters(
+  sites: SiteAttestation[],
+  search: string,
+  status: StatusFilter,
+): SiteAttestation[] {
+  const q = search.trim().toLowerCase();
+  return sites.filter(s =>
+    matchesStatusFilter(s, status) &&
+    (q === "" || s.site_id.toLowerCase().includes(q))
+  );
+}
+
+interface FilterBarProps {
+  search: string;
+  onSearch: (v: string) => void;
+  status: StatusFilter;
+  onStatus: (v: StatusFilter) => void;
+  sites: SiteAttestation[];
+  filteredCount: number;
+}
+
+function FilterBar({ search, onSearch, status, onStatus, sites, filteredCount }: FilterBarProps) {
+  const counts: Record<StatusFilter, number> = {
+    all:             sites.length,
+    certified:       sites.filter(s => matchesStatusFilter(s, "certified")).length,
+    below_standard:  sites.filter(s => matchesStatusFilter(s, "below_standard")).length,
+    integrity_issue: sites.filter(s => matchesStatusFilter(s, "integrity_issue")).length,
+    no_records:      sites.filter(s => matchesStatusFilter(s, "no_records")).length,
+  };
+
+  return (
+    <div style={{ marginBottom: 12 }}>
+      {/* Search */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
+        <div style={{ position: "relative", flex: 1, maxWidth: 320 }}>
+          <span style={{
+            position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)",
+            color: "#8b949e", fontSize: 13, pointerEvents: "none",
+          }}>🔍</span>
+          <input
+            type="text"
+            placeholder="Search by site ID…"
+            value={search}
+            onChange={e => onSearch(e.target.value)}
+            style={{
+              width: "100%", boxSizing: "border-box",
+              background: "#0d1117", border: "1px solid #30363d", borderRadius: 6,
+              color: "#e6edf3", fontSize: 13, padding: "7px 12px 7px 32px",
+              outline: "none",
+            }}
+          />
+          {search && (
+            <button
+              onClick={() => onSearch("")}
+              style={{
+                position: "absolute", right: 8, top: "50%", transform: "translateY(-50%)",
+                background: "none", border: "none", color: "#8b949e", cursor: "pointer",
+                fontSize: 14, padding: 0, lineHeight: 1,
+              }}
+            >×</button>
+          )}
+        </div>
+        <span style={{ fontSize: 12, color: "#8b949e", whiteSpace: "nowrap" }}>
+          {filteredCount === sites.length
+            ? `${sites.length} site${sites.length !== 1 ? "s" : ""}`
+            : `${filteredCount} of ${sites.length} sites`}
+        </span>
+      </div>
+
+      {/* Status filter pills */}
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+        {STATUS_FILTERS.filter(f => counts[f.key] > 0 || f.key === "all").map(f => (
+          <button
+            key={f.key}
+            onClick={() => onStatus(f.key)}
+            style={{
+              padding: "4px 12px", borderRadius: 20, fontSize: 12, cursor: "pointer",
+              border: status === f.key ? "1px solid #58a6ff" : "1px solid #30363d",
+              background: status === f.key ? "rgba(88,166,255,0.15)" : "#161b22",
+              color: status === f.key ? "#58a6ff" : "#8b949e",
+              fontWeight: status === f.key ? 600 : 400,
+            }}
+          >
+            {f.label}
+            <span style={{ marginLeft: 5, opacity: 0.7 }}>{counts[f.key]}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 // ── Main view ─────────────────────────────────────────────────────────────────
 
 interface Props {
@@ -306,6 +419,8 @@ export function AttestationView({ operators }: Props) {
   const [selectedOperator, setSelectedOperator] = useState<string>("MCH-OPERATOR-001");
   const [portfolio, setPortfolio]         = useState<PortfolioAttestation | null>(null);
   const [loading, setLoading]             = useState(false);
+  const [search, setSearch]               = useState("");
+  const [statusFilter, setStatusFilter]   = useState<StatusFilter>("all");
 
   useEffect(() => {
     fetchBcaSiteRegistry()
@@ -326,10 +441,16 @@ export function AttestationView({ operators }: Props) {
     if (!siteIds?.length) return;
     setLoading(true);
     setPortfolio(null);
+    setSearch("");
+    setStatusFilter("all");
     fetchPortfolioAttestation(selectedOperator, siteIds)
       .then(setPortfolio)
       .finally(() => setLoading(false));
   }, [selectedOperator, registry]);
+
+  const filteredSites = portfolio
+    ? applySiteFilters(portfolio.sites, search, statusFilter)
+    : [];
 
   return (
     <div style={{ padding: "24px", maxWidth: 1000, margin: "0 auto" }}>
@@ -394,38 +515,51 @@ export function AttestationView({ operators }: Props) {
         </div>
       )}
 
-      {/* Site table */}
+      {/* Filter bar + site table */}
       {portfolio && !loading && (
-        <div style={{
-          background: "#161b22", border: "1px solid #30363d", borderRadius: 10, overflow: "hidden",
-        }}>
-          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
-            <thead>
-              <tr style={{ borderBottom: "1px solid #30363d" }}>
-                {[
-                  "Site",
-                  "Certification Level",
-                  "EUI (kWh/m²/yr)",
-                  "Status",
-                  "Verified At",
-                  "",
-                ].map(label => (
-                  <th key={label} style={{
-                    fontSize: 11, textTransform: "uppercase", letterSpacing: "0.06em",
-                    color: "#8b949e", padding: "10px 16px", textAlign: "left",
-                  }}>
-                    {label}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {portfolio.sites.map(site => (
-                <SiteRow key={site.site_id} site={site} />
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <>
+          <FilterBar
+            search={search}
+            onSearch={setSearch}
+            status={statusFilter}
+            onStatus={setStatusFilter}
+            sites={portfolio.sites}
+            filteredCount={filteredSites.length}
+          />
+
+          <div style={{
+            background: "#161b22", border: "1px solid #30363d", borderRadius: 10, overflow: "hidden",
+          }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+              <thead>
+                <tr style={{ borderBottom: "1px solid #30363d" }}>
+                  {["Site", "Certification Level", "EUI (kWh/m²/yr)", "Status", "Verified At", ""].map(label => (
+                    <th key={label} style={{
+                      fontSize: 11, textTransform: "uppercase", letterSpacing: "0.06em",
+                      color: "#8b949e", padding: "10px 16px", textAlign: "left",
+                    }}>
+                      {label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {filteredSites.length > 0
+                  ? filteredSites.map(site => <SiteRow key={site.site_id} site={site} />)
+                  : (
+                    <tr>
+                      <td colSpan={6} style={{
+                        padding: "32px 16px", textAlign: "center",
+                        color: "#8b949e", fontSize: 13,
+                      }}>
+                        No sites match the current filter.
+                      </td>
+                    </tr>
+                  )}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
 
       {/* Footer note */}

--- a/app/src/lib/attestation.test.ts
+++ b/app/src/lib/attestation.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+// @ts-ignore
+import { blake3 } from "@noble/hashes/blake3.js";
 import {
   certLevelLabel,
   certLevelColor,
@@ -7,6 +9,10 @@ import {
   type GreenMarkAttestation,
   type ZkProof,
 } from "./attestation.js";
+
+function b64Encode(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -25,11 +31,13 @@ function makeAttestation(overrides: Partial<GreenMarkAttestation> = {}): GreenMa
 }
 
 function makeProof(att: GreenMarkAttestation): ZkProof {
+  const pubValJson  = JSON.stringify(att);
+  const pubValBytes = new TextEncoder().encode(pubValJson);
   return {
-    framework: "mock",
-    program_id: "bca-green-mark-2021-v1-mock",
-    proof_bytes: "dGVzdA==",
-    public_values: btoa(JSON.stringify(att)),
+    framework:    "mock",
+    program_id:   "bca-green-mark-2021-v1-mock",
+    proof_bytes:  b64Encode(blake3(pubValBytes)),  // valid mock: blake3(public_values_bytes)
+    public_values: btoa(pubValJson),
   };
 }
 

--- a/app/src/lib/attestation.ts
+++ b/app/src/lib/attestation.ts
@@ -9,6 +9,10 @@
  * only the public attestation committed by the ZkProgram is read.
  */
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — @noble/hashes uses .ts extensions internally; works at runtime
+import { blake3 } from "@noble/hashes/blake3.js";
+
 const CLARUS_AUDIT_BASE = "https://clarus.edgesentry.io";
 
 // ── Types mirroring clarus/edge/src/zkp/green_mark.rs ────────────────────────
@@ -47,7 +51,10 @@ export interface SiteAttestation {
   attestation: GreenMarkAttestation | null;
   record_hash: string | null;
   attested_at: Date | null;
+  /** True when proof_bytes verifies against public_values (BLAKE3 for mock, Groth16 for SP1). */
   verified: boolean;
+  /** Null = not attempted; true = proof matches; false = proof is invalid/tampered. */
+  proof_valid: boolean | null;
   error?: string;
 }
 
@@ -60,7 +67,51 @@ export interface PortfolioAttestation {
   total_count: number;
 }
 
+// ── Site registry ─────────────────────────────────────────────────────────────
+
+export interface SiteRegistryEntry {
+  site_id: string;
+  name: string;
+  operator_id: string;
+  profile: string;
+  e2e_scenario?: string;
+}
+
+export interface SiteRegistry {
+  version: string;
+  sites: SiteRegistryEntry[];
+}
+
+export async function fetchBcaSiteRegistry(): Promise<SiteRegistry> {
+  const res = await fetch(`${CLARUS_AUDIT_BASE}/data/raw/registry/bca-sites.json`);
+  if (!res.ok) throw new Error(`registry fetch failed: ${res.status}`);
+  return res.json() as Promise<SiteRegistry>;
+}
+
+/** Returns site IDs grouped by operator_id. */
+export function sitesByOperator(registry: SiteRegistry): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+  for (const s of registry.sites) {
+    if (!result[s.operator_id]) result[s.operator_id] = [];
+    result[s.operator_id].push(s.site_id);
+  }
+  return result;
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+function b64Decode(s: string): Uint8Array {
+  const bin = atob(s);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+  return arr;
+}
+
+function arrEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
 
 function decodeAttestation(proof: ZkProof): GreenMarkAttestation | null {
   try {
@@ -71,12 +122,33 @@ function decodeAttestation(proof: ZkProof): GreenMarkAttestation | null {
   }
 }
 
-function verifMockProof(proof: ZkProof, _attestation: GreenMarkAttestation): boolean {
-  // Mock framework: proof_bytes = blake3(public_values).
-  // In-browser we can't run blake3, so we accept mock proofs as verified
-  // and note the framework in the UI.  Real SP1 proofs will use Groth16
-  // which can be verified in-browser with the sp1-verifier WASM module.
-  return proof.framework === "mock" || proof.framework === "sp1";
+/**
+ * Verify the ZKP proof bytes against its public values.
+ *
+ * Mock framework: proof_bytes = BLAKE3(public_values_bytes)
+ *   → verifiable in-browser with @noble/hashes/blake3
+ *
+ * SP1 framework: would require Groth16 WASM verifier (not yet integrated).
+ *   → currently accepted as-is (returns true) pending SP1 verifier integration.
+ *
+ * Returns null if verification is not supported for the framework.
+ */
+function verifyProof(proof: ZkProof): boolean | null {
+  if (proof.framework === "mock") {
+    try {
+      const pubValBytes = b64Decode(proof.public_values);
+      const expected    = blake3(pubValBytes);          // 32-byte Uint8Array
+      const actual      = b64Decode(proof.proof_bytes); // should also be 32 bytes
+      return arrEqual(expected, actual);
+    } catch {
+      return false;
+    }
+  }
+  if (proof.framework === "sp1") {
+    // Groth16 in-browser verification pending SP1 WASM verifier integration
+    return null;
+  }
+  return null;
 }
 
 // ── Clarus API fetch ──────────────────────────────────────────────────────────
@@ -94,7 +166,7 @@ async function fetchAuditSummary(siteId: string): Promise<{ runs: Array<{ run_id
     }
   } catch { /* no pointer yet */ }
 
-  // 2. Try /api/audit-summary (clarus#100). Falls through if not yet deployed.
+  // 2. Try /api/audit-summary. Falls through if not yet deployed.
   try {
     const res = await fetch(`${CLARUS_AUDIT_BASE}/api/audit-summary?site=${encodeURIComponent(siteId)}`);
     if (res.ok) {
@@ -141,7 +213,7 @@ export async function fetchSiteAttestation(siteId: string): Promise<SiteAttestat
   try {
     const { runs } = await fetchAuditSummary(siteId);
     if (runs.length === 0) {
-      return { site_id: siteId, attestation: null, record_hash: null, attested_at: null, verified: false, error: "no runs" };
+      return { site_id: siteId, attestation: null, record_hash: null, attested_at: null, verified: false, proof_valid: null, error: "no runs" };
     }
 
     // Try newest run first; scan last 10 records for one with zk_proof
@@ -156,32 +228,35 @@ export async function fetchSiteAttestation(siteId: string): Promise<SiteAttestat
       const att = decodeAttestation(record.zk_proof);
       if (!att) continue;
 
-      const verified = verifMockProof(record.zk_proof, att);
+      const proof_valid = verifyProof(record.zk_proof);
+      const verified    = proof_valid === true || proof_valid === null; // null = unverifiable (SP1 pending)
       return {
         site_id: siteId,
         attestation: att,
         record_hash: record.record_hash_hex ?? null,
         attested_at: new Date(record.timestamp_ms),
         verified,
+        proof_valid,
       };
     }
 
-    return { site_id: siteId, attestation: null, record_hash: null, attested_at: null, verified: false, error: "no zk_proof in recent records" };
+    return { site_id: siteId, attestation: null, record_hash: null, attested_at: null, verified: false, proof_valid: null, error: "no zk_proof in recent records" };
   } catch (e) {
-    return { site_id: siteId, attestation: null, record_hash: null, attested_at: null, verified: false, error: String(e) };
+    return { site_id: siteId, attestation: null, record_hash: null, attested_at: null, verified: false, proof_valid: null, error: String(e) };
   }
 }
 
 /**
  * Fetch ZKP attestations for all sites belonging to an operator.
- * `siteIds` comes from the BCA portfolio parquet (operator → sites).
+ * `siteIds` comes from the BCA site registry or BCA portfolio parquet.
  */
 export async function fetchPortfolioAttestation(
   operatorId: string,
   siteIds: string[],
 ): Promise<PortfolioAttestation> {
   const sites = await Promise.all(siteIds.map(fetchSiteAttestation));
-  const passCount = sites.filter(s => s.attestation?.all_criteria_pass === true).length;
+  // Only count sites with verified proofs toward pass count
+  const passCount = sites.filter(s => s.attestation?.all_criteria_pass === true && s.proof_valid !== false).length;
 
   return {
     operator_id: operatorId,


### PR DESCRIPTION
## Summary

- Reads BCA site list from R2 registry (`clarus.edgesentry.io/data/raw/registry/bca-sites.json`) at runtime — no more hardcoded `OPERATOR_SITE_MAP`
- Verifies ZKP proof_bytes in-browser using real BLAKE3 (`@noble/hashes`)
- Shows `✓ valid` / `✗ TAMPERED` / `SP1 (pending)` per site
- Highlights tampered rows in red; summary banner shows 🚨 when fraud/sabotage detected

## 4-quadrant E2E test results in documaris

| Site | Cert Level | All Criteria | ZKP Proof |
|---|---|---|---|
| MCH-OUTLET-042 | Gold | ✓ PASS | ✓ valid |
| BLD-HIGHUSE-FAIL | Not Certified | ✗ FAIL | ✓ valid |
| BLD-TAMPER-PASS | GoldPlus (claimed) | ⚠ UNVERIFIED | ✗ TAMPERED |
| BLD-TAMPER-FAIL | Not Certified (claimed) | ✗ FAIL | ✗ TAMPERED |

## Test plan

- [ ] Open `http://localhost:5174/?mode=bca`
- [ ] BCA tab loads with registry label "4 sites from R2 registry"
- [ ] MCH-OUTLET-042: Gold badge, ✓ valid proof, all_criteria=PASS
- [ ] BLD-HIGHUSE-FAIL: Not Certified badge, ✓ valid proof, all_criteria=FAIL
- [ ] BLD-TAMPER-PASS: GoldPlus badge but "✗ TAMPERED", red row, "⚠ PROOF INVALID"
- [ ] BLD-TAMPER-FAIL: Not Certified but "✗ TAMPERED", red row
- [ ] Summary banner shows 🚨 "2 tampered/forged proofs detected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)