### PR TITLE
docs(agents): clarify responsibility boundary — documaris is operator UI, not verifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,26 @@ Multi-profile document generation and compliance automation platform. documaris 
 
 Supported profiles: `fal-form-1` / `fal-form-5` (maritime port call, PIER71), `sg-bca-greenmark` (BCA Green Mark Section 4, BEAMP). Same pipeline core — only the parser, field map, HTML template, and rules differ per profile.
 
+## Responsibility boundary
+
+documaris is the **operator-facing UI and compliance document platform**.
+
+```
+documaris owns:
+  - Compliance document generation (FAL forms, BCA Green Mark reports)
+  - Operator portfolio UI (browser-side, DuckDB WASM, zero server cost)
+  - Browser-side ZKP attestation verification (@noble/hashes/blake3)
+
+documaris does NOT own:
+  - Proof data or WORM chain storage (→ clarus R2)
+  - B2B verification endpoints (→ clarus /api/verify)
+  - ZKP proof generation (→ clarus edge daemon)
+  - Domain-agnostic crypto primitives (→ edgesentry-rs eds-zkp)
+```
+
+Generated compliance documents embed `verify_url` pointing to `clarus.edgesentry.io/api/verify`
+so recipients can independently verify without going through documaris.
+
 ## Related repos
 
 | Repo | Role | Relationship |
@@ -11,7 +31,7 @@ Supported profiles: `fal-form-1` / `fal-form-5` (maritime port call, PIER71), `s
 | [indago](https://github.com/edgesentry/indago) | Data layer | Writes vessel/voyage/cargo Parquet to documaris R2 bucket — documaris reads from it |
 | [edgesentry-rs](https://github.com/edgesentry/edgesentry-rs) | Audit chain | Trust Layer reuses `edgesentry-audit` crate (BLAKE3 + Ed25519) |
 | [arktrace](https://github.com/edgesentry/arktrace) | Shadow fleet detection | Shares the same vessel entity (MMSI); documaris closes the compliance loop |
-| [clarus](https://github.com/edgesentry/clarus) | Profile-switchable safety monitoring | Sister product — `?mmsi=` deep-link cross-navigation |
+| [clarus](https://github.com/edgesentry/clarus) | Data + verification layer | Owns WORM chain, ZKP proofs, and B2B `/api/verify` endpoint — documaris reads from it |
 
 ## Directory map
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21,6 +21,7 @@
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
         "@vitest/coverage-v8": "^4.1.5",
+        "ajv": "^8.20.0",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.26",
@@ -1038,6 +1039,30 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.39.4",
@@ -2285,16 +2310,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -3057,6 +3082,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -3161,6 +3210,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3698,9 +3764,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -4257,6 +4323,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {

--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
     "@vitest/coverage-v8": "^4.1.5",
+    "ajv": "^8.20.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.26",

--- a/app/src/lib/zk-attestation-schema.test.ts
+++ b/app/src/lib/zk-attestation-schema.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Contract tests: validate attestation.ts fixtures against
+ * clarus/schemas/zk-attestation.json — the canonical type definition
+ * owned by clarus (source of truth for both Rust and TypeScript types).
+ *
+ * If clarus changes GreenMarkAttestation or ZkProof, this test fails,
+ * forcing a documaris update before the divergence reaches production.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import Ajv from "ajv/dist/2020.js";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { blake3 } from "@noble/hashes/blake3.js";
+import type { GreenMarkAttestation, ZkProof } from "./attestation.js";
+
+// Load schema from clarus repo (sibling directory — see AGENTS.md checkout requirement)
+const schemaPath = resolve(__dirname, "../../../../clarus/schemas/zk-attestation.json");
+const schema = JSON.parse(readFileSync(schemaPath, "utf-8"));
+
+const ajv = new Ajv({ strict: true });
+ajv.addSchema(schema);
+const validateZkProof = ajv.compile({ $ref: "https://clarus.edgesentry.io/schemas/zk-attestation.json#/$defs/ZkProof" });
+const validateAttestation = ajv.compile({ $ref: "https://clarus.edgesentry.io/schemas/zk-attestation.json#/$defs/GreenMarkAttestation" });
+
+// ── Fixture helpers (mirror of attestation.test.ts) ───────────────────────────
+
+function b64Encode(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+function makeAttestation(overrides: Partial<GreenMarkAttestation> = {}): GreenMarkAttestation {
+  return {
+    site_id: "MCH-OUTLET-042",
+    eui_kwh_m2: 105.0,
+    cert_level: "gold",
+    all_criteria_pass: true,
+    cop_pass: true,
+    lpd_pass: true,
+    period_start_ms: 1_000_000,
+    period_end_ms: 2_000_000,
+    ...overrides,
+  };
+}
+
+function makeProof(att: GreenMarkAttestation): ZkProof {
+  const json      = JSON.stringify(att);
+  const bytes     = new TextEncoder().encode(json);
+  return {
+    framework:     "mock",
+    program_id:    "bca-green-mark-2021-v1-mock",
+    proof_bytes:   b64Encode(blake3(bytes)),
+    public_values: btoa(json),
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("zk-attestation schema — ZkProof", () => {
+  it("valid mock proof passes schema", () => {
+    const proof = makeProof(makeAttestation());
+    const ok = validateZkProof(proof);
+    expect(ok, JSON.stringify(validateZkProof.errors)).toBe(true);
+  });
+
+  it("all three frameworks are valid enum values", () => {
+    for (const framework of ["mock", "sp1", "risc0"] as const) {
+      const proof = { ...makeProof(makeAttestation()), framework };
+      expect(validateZkProof(proof), `framework=${framework}`).toBe(true);
+    }
+  });
+
+  it("unknown framework fails schema", () => {
+    const proof = { ...makeProof(makeAttestation()), framework: "groth16" };
+    expect(validateZkProof(proof)).toBe(false);
+  });
+
+  it("missing proof_bytes fails schema", () => {
+    const { proof_bytes: _, ...proof } = makeProof(makeAttestation());
+    expect(validateZkProof(proof)).toBe(false);
+  });
+
+  it("extra fields fail schema (additionalProperties: false)", () => {
+    const proof = { ...makeProof(makeAttestation()), extra: "field" };
+    expect(validateZkProof(proof)).toBe(false);
+  });
+});
+
+describe("zk-attestation schema — GreenMarkAttestation", () => {
+  it("valid Gold attestation passes schema", () => {
+    const att = makeAttestation();
+    expect(validateAttestation(att), JSON.stringify(validateAttestation.errors)).toBe(true);
+  });
+
+  it("all cert levels are valid", () => {
+    const levels = ["not_certified", "certified", "gold", "gold_plus", "platinum"] as const;
+    for (const cert_level of levels) {
+      const att = makeAttestation({ cert_level });
+      expect(validateAttestation(att), `cert_level=${cert_level}`).toBe(true);
+    }
+  });
+
+  it("unknown cert level fails schema", () => {
+    const att = { ...makeAttestation(), cert_level: "diamond" };
+    expect(validateAttestation(att)).toBe(false);
+  });
+
+  it("negative eui_kwh_m2 fails schema", () => {
+    const att = makeAttestation({ eui_kwh_m2: -1 });
+    expect(validateAttestation(att)).toBe(false);
+  });
+
+  it("missing required field fails schema", () => {
+    const { cop_pass: _, ...att } = makeAttestation();
+    expect(validateAttestation(att)).toBe(false);
+  });
+
+  it("extra fields fail schema (additionalProperties: false)", () => {
+    const att = { ...makeAttestation(), extra: "field" };
+    expect(validateAttestation(att)).toBe(false);
+  });
+
+  it("violation attestation (not_certified, all_criteria_pass=false) passes schema", () => {
+    const att = makeAttestation({ cert_level: "not_certified", all_criteria_pass: false });
+    expect(validateAttestation(att), JSON.stringify(validateAttestation.errors)).toBe(true);
+  });
+});

--- a/app/src/lib/zk-bca-greenmark-schema.test.ts
+++ b/app/src/lib/zk-bca-greenmark-schema.test.ts
@@ -14,13 +14,13 @@ import { blake3 } from "@noble/hashes/blake3.js";
 import type { GreenMarkAttestation, ZkProof } from "./attestation.js";
 
 // Load schema from clarus repo (sibling directory — see AGENTS.md checkout requirement)
-const schemaPath = resolve(__dirname, "../../../../clarus/schemas/zk-attestation.json");
+const schemaPath = resolve(__dirname, "../../../../clarus/schemas/zk-bca-greenmark.json");
 const schema = JSON.parse(readFileSync(schemaPath, "utf-8"));
 
 const ajv = new Ajv({ strict: true });
 ajv.addSchema(schema);
-const validateZkProof = ajv.compile({ $ref: "https://clarus.edgesentry.io/schemas/zk-attestation.json#/$defs/ZkProof" });
-const validateAttestation = ajv.compile({ $ref: "https://clarus.edgesentry.io/schemas/zk-attestation.json#/$defs/GreenMarkAttestation" });
+const validateZkProof = ajv.compile({ $ref: "https://clarus.edgesentry.io/schemas/zk-bca-greenmark.json#/$defs/ZkProof" });
+const validateAttestation = ajv.compile({ $ref: "https://clarus.edgesentry.io/schemas/zk-bca-greenmark.json#/$defs/GreenMarkAttestation" });
 
 // ── Fixture helpers (mirror of attestation.test.ts) ───────────────────────────
 

--- a/app/src/lib/zk-bca-greenmark-schema.test.ts
+++ b/app/src/lib/zk-bca-greenmark-schema.test.ts
@@ -6,7 +6,7 @@
  * If clarus changes GreenMarkAttestation or ZkProof, this test fails,
  * forcing a documaris update before the divergence reaches production.
  */
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import Ajv from "ajv/dist/2020.js";
 import { readFileSync } from "fs";
 import { resolve } from "path";


### PR DESCRIPTION
## Summary

- Documents the confirmed responsibility split: edgesentry-rs / clarus / documaris
- Clarifies documaris owns operator UI + compliance document generation, NOT proof data or verification infrastructure
- Notes that generated documents embed `verify_url` → clarus for independent verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)