### PR TITLE
feat(bca): wire App.tsx to pass site_id and render htmlWithAttestation

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -438,7 +438,7 @@ describe("App — BCA document generation", () => {
   it("calls runBcaPipeline with the selected site's CSV", async () => {
     await generateBcaDoc();
     expect(vi.mocked(runBcaPipeline)).toHaveBeenCalledOnce();
-    expect(vi.mocked(runBcaPipeline)).toHaveBeenCalledWith(MOCK_BCA_SCENARIO.csv);
+    expect(vi.mocked(runBcaPipeline)).toHaveBeenCalledWith(MOCK_BCA_SCENARIO.csv, expect.any(String));
   });
 
   it("shows the BCA Section 4 document heading in result", async () => {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -118,7 +118,7 @@ export default function App() {
     setBcaPhase({ tag: "generating", site });
     try {
       const scenario: BcaScenario = siteSummaryToBcaScenario(site);
-      const result = await runBcaPipeline(scenario.csv);
+      const result = await runBcaPipeline(scenario.csv, site.outlet_id);
       setBcaPhase({ tag: "result", site, result });
     } catch (e) {
       setBcaPhase({ tag: "error", message: String(e), back: "operator", operator });
@@ -282,7 +282,7 @@ export default function App() {
               <h2>BCA Green Mark — Section 4</h2>
               <div
                 className="fal-form"
-                dangerouslySetInnerHTML={{ __html: bcaResult.html }}
+                dangerouslySetInnerHTML={{ __html: bcaResult.htmlWithAttestation }}
               />
             </section>
           </div>


### PR DESCRIPTION
## Summary

Follow-up to #64. Wires the UI to actually use the ZKP attestation-enriched HTML.

## Changes

- `App.tsx` — `handleSiteSelect` passes `site.outlet_id` to `runBcaPipeline()`  
- `App.tsx` — BCA result view renders `htmlWithAttestation` instead of `html`  
- `App.test.tsx` — updated assertion to expect `(csv, siteId)` call signature

## Test plan

- [x] 183/183 tests pass
- [x] Local dev server: BCA report now shows ZKP attestation section at bottom of document

🤖 Generated with [Claude Code](https://claude.com/claude-code)