### PR TITLE
feat(bca): add Proof integrity row and independent verification link

### DIFF
--- a/app/src/components/AttestationView.tsx
+++ b/app/src/components/AttestationView.tsx
@@ -173,6 +173,13 @@ function SiteRow({ site }: { site: SiteAttestation }) {
                     <span style={{ color: att.lpd_pass ? "#3fb950" : "#f85149" }}>
                       {att.lpd_pass ? "✓ Meets standard (≤ 15 W/m²)" : "✗ Above limit (> 15 W/m²)"}
                     </span>
+
+                    <span style={{ color: "#8b949e" }}>Proof integrity</span>
+                    <span style={{ color: site.proof_valid === true ? "#3fb950" : site.proof_valid === false ? "#f85149" : "#8b949e", fontWeight: 600 }}>
+                      {site.proof_valid === true  ? "✓ Verified" :
+                       site.proof_valid === false ? "✗ Tampered" :
+                                                    "Pending"}
+                    </span>
                   </div>
                 </div>
 
@@ -214,6 +221,16 @@ function SiteRow({ site }: { site: SiteAttestation }) {
                   <div style={{ fontSize: 12, color: "#8b949e", lineHeight: 1.6 }}>
                     <div>Record ID: <span style={{ fontFamily: "monospace", fontSize: 11 }}>{site.record_hash?.slice(0, 16) ?? "—"}…</span></div>
                     <div style={{ marginTop: 4 }}>Stored in tamper-evident, deletion-proof storage. Cannot be modified after the fact.</div>
+                    <div style={{ marginTop: 6 }}>
+                      <a
+                        href={`https://clarus.edgesentry.io/api/verify?site=${encodeURIComponent(site.site_id)}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{ color: "#58a6ff", fontSize: 11 }}
+                      >
+                        Independent verification ↗
+                      </a>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Adds **Proof integrity** row to the BCA Compliance Criteria grid: shows ✓ Verified / ✗ Tampered / Pending based on `proof_valid`
- Adds **Independent verification ↗** link in the Audit Record section pointing to `clarus.edgesentry.io/api/verify?site=...`

## Test plan
- [ ] Select MCH-OUTLET-042 in documaris BCA mode → expanded row shows **Proof integrity: ✓ Verified** (green)
- [ ] Select a tampered site (BLD-TAMPER-PASS) → shows **✗ Tampered** (red)
- [ ] Click Independent verification link → opens clarus /api/verify in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)