### PR TITLE
fix: remove htmlWithAttestation from test fixture, suppress unused siteId

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -147,7 +147,6 @@ const MOCK_BCA_RESULT: BcaPipelineResult = {
   },
   alerts: [],
   html: "<table><tr><td>BCA Green Mark Section 4</td></tr></table>",
-  htmlWithAttestation: "<table><tr><td>BCA Green Mark Section 4</td></tr></table>",
   auditRecord: {
     device_id: "documaris-demo", sequence: 1, timestamp_ms: 0,
     payload_hash: [], signature: [], prev_record_hash: [],

--- a/app/src/lib/pipeline.ts
+++ b/app/src/lib/pipeline.ts
@@ -176,7 +176,7 @@ export const BCA_GREEN_MARK_RULES = JSON.stringify([
 
 export async function runBcaPipeline(
   csv: string,
-  siteId?: string,
+  _siteId?: string,
 ): Promise<BcaPipelineResult> {
   // Architecture proof: steps 3–5 are byte-for-byte identical to runPipeline().
   // Only parse_bca_csv → fill_bca → render_html("sg-bca-greenmark") differ.


### PR DESCRIPTION
Fixes build failure after #68 merged.

- `App.test.tsx`: remove `htmlWithAttestation` from `BcaPipelineResult` fixture (field was deleted in #68)
- `pipeline.ts`: rename `siteId` → `_siteId` to suppress TS6133 unused variable error

🤖 Generated with [Claude Code](https://claude.com/claude-code)